### PR TITLE
Build: Fix appveyor build caused by faulty nuget push

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,8 +34,10 @@ artifacts:
     - path: doc
       name: Generated documentation
       type: zip
-    - path: '**\*.nupkg'
-      name: NuGet Packages
+    - path: 'Snowflake\*.nupkg'
+      name: Snowflake NuGet Packages
+    - path: 'Snowflake.API\*.nupkg'
+      name: Snowflake.API NuGet Packages
 assembly_info:
     patch: true
     file: SharedAssemblyInfo.cs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,13 +14,13 @@ environment:
     COVERALLS_REPO_TOKEN:
       secure: nBi3LwnqgslaH8hbsvjnWTqpe/UbKn705TJujxqJwtcL5OLGfcydM8AnVyld6Ngu
     MYGET_API_KEY:
-      secure: hSOYKRU/7k20SWxH5ZnDA/enAg7LNbU5rIVc/FuoPrFTpbAAREyVt9ahbtX8SlP6
+      secure: c0TSni4oM3D75P31isNFRu0z4whPsrvTAcu67iLlFmtvvrzopEI8Xj5qWk1pwMkj
 install:
     - choco install doxygen.portable
     - nuget restore
 after_build:
-    - echo Generating documentation
-    - doxygen.exe "C:\projects\snowflake\snowflake.doxygen"
+    - echo Generating doxygen documentation
+    - doxygen.exe "C:\projects\snowflake\snowflake.doxygen" 2> nul
 after_test:
     - echo Generating Code Coverage Report
     - packages\OpenCover.4.5.3522\OpenCover.Console.exe -register:user -filter:"+[Snowflake*]*" -target:"packages/xunit.runners.2.0.0-rc1-build2826\tools\xunit.console.exe" -targetargs:"Snowflake.Tests\bin\%CONFIGURATION%\Snowflake.Tests.dll -noshadow" -output:coverage.xml
@@ -29,12 +29,15 @@ after_test:
     - echo Packing NuGet packages
     - nuget pack Snowflake\Snowflake.csproj -IncludeReferencedProjects -Symbols
     - nuget pack Snowflake.API\Snowflake.API.csproj -IncludeReferencedProjects  -Symbols
-    - echo Uploading NuGet packages to MyGet snowflake-nightly feed
-    - nuget setApiKey %MYGET_API_KEY%
-    - nuget push Snowflake.API.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.nupkg -Source https://www.myget.org/F/snowflake-nightly/api/v2/package
-    - nuget push Snowflake.API.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.Symbols.nupkg -Source https://nuget.symbolsource.org/MyGet/snowflake-nightly
-    - nuget push Snowflake.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.nupkg -Source https://www.myget.org/F/snowflake-nightly/api/v2/package
-    - nuget push Snowflake.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.Symbols.nupkg -Source https://nuget.symbolsource.org/MyGet/snowflake-nightly
+    - cmd: |
+        echo Uploading NuGet packages to MyGet snowflake-nightly feed
+        nuget setApiKey %MYGET_API_KEY% -Source https://www.myget.org/F/snowflake-nightly/api/v2/package 2> nul
+        nuget setApiKey %MYGET_API_KEY% -Source https://nuget.symbolsource.org/MyGet/snowflake-nightly 2> nul
+        nuget push Snowflake.API.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.nupkg -Source https://www.myget.org/F/snowflake-nightly/api/v2/package
+        nuget push Snowflake.API.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.Symbols.nupkg -Source https://nuget.symbolsource.org/MyGet/snowflake-nightly
+        nuget push Snowflake.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.nupkg -Source https://www.myget.org/F/snowflake-nightly/api/v2/package
+        nuget push Snowflake.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.Symbols.nupkg -Source https://nuget.symbolsource.org/MyGet/snowflake-nightly
+        exit /b 0
 artifacts:
     - path: Snowflake\bin\$(configuration)
       name: Snowflake Base Libraries

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,11 @@ artifacts:
     - path: doc
       name: Generated documentation
       type: zip
+    - path: doc
+      name: Generated documentation
+      type: zip
+    - path: '**\*.nupkg'
+      name: NuGet Packages
 assembly_info:
     patch: true
     file: SharedAssemblyInfo.cs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,9 +34,6 @@ artifacts:
     - path: doc
       name: Generated documentation
       type: zip
-    - path: doc
-      name: Generated documentation
-      type: zip
     - path: '**\*.nupkg'
       name: NuGet Packages
 assembly_info:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ test:
 configuration: Debug
 build:
   project: Snowflake.sln
+  publish_nuget: true
+  publish_nuget_symbols: true
+  verbosity: minimal
 environment:
     COVERALLS_REPO_TOKEN:
       secure: nBi3LwnqgslaH8hbsvjnWTqpe/UbKn705TJujxqJwtcL5OLGfcydM8AnVyld6Ngu
@@ -45,10 +48,9 @@ assembly_info:
     assembly_file_version: '{version}'
     assembly_informational_version: '{version}-pre-alpha-nightly'
 deploy:
-  provider: NuGet
+- provider: NuGet
   server: https://www.myget.org/F/snowflake-nightly/api/v2/package
   api_key:
     secure: c0TSni4oM3D75P31isNFRu0z4whPsrvTAcu67iLlFmtvvrzopEI8Xj5qWk1pwMkj
-  skip_symbols: false
   symbol_server: https://nuget.symbolsource.org/MyGet/snowflake-nightly
-  artifact: /.*\.nupkg/
+  artifact: Snowflake.*\.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,6 @@ build:
 environment:
     COVERALLS_REPO_TOKEN:
       secure: nBi3LwnqgslaH8hbsvjnWTqpe/UbKn705TJujxqJwtcL5OLGfcydM8AnVyld6Ngu
-    MYGET_API_KEY:
-      secure: c0TSni4oM3D75P31isNFRu0z4whPsrvTAcu67iLlFmtvvrzopEI8Xj5qWk1pwMkj
 install:
     - choco install doxygen.portable
     - nuget restore
@@ -29,15 +27,6 @@ after_test:
     - echo Packing NuGet packages
     - nuget pack Snowflake\Snowflake.csproj -IncludeReferencedProjects -Symbols
     - nuget pack Snowflake.API\Snowflake.API.csproj -IncludeReferencedProjects  -Symbols
-    - cmd: |
-        echo Uploading NuGet packages to MyGet snowflake-nightly feed
-        nuget setApiKey %MYGET_API_KEY% -Source https://www.myget.org/F/snowflake-nightly/api/v2/package 2> nul
-        nuget setApiKey %MYGET_API_KEY% -Source https://nuget.symbolsource.org/MyGet/snowflake-nightly 2> nul
-        nuget push Snowflake.API.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.nupkg -Source https://www.myget.org/F/snowflake-nightly/api/v2/package
-        nuget push Snowflake.API.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.Symbols.nupkg -Source https://nuget.symbolsource.org/MyGet/snowflake-nightly
-        nuget push Snowflake.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.nupkg -Source https://www.myget.org/F/snowflake-nightly/api/v2/package
-        nuget push Snowflake.%APPVEYOR_BUILD_VERSION%-pre-alpha-nightly.Symbols.nupkg -Source https://nuget.symbolsource.org/MyGet/snowflake-nightly
-        exit /b 0
 artifacts:
     - path: Snowflake\bin\$(configuration)
       name: Snowflake Base Libraries
@@ -51,3 +40,11 @@ assembly_info:
     assembly_version: '{version}'
     assembly_file_version: '{version}'
     assembly_informational_version: '{version}-pre-alpha-nightly'
+deploy:
+  provider: NuGet
+  server: https://www.myget.org/F/snowflake-nightly/api/v2/package
+  api_key:
+    secure: c0TSni4oM3D75P31isNFRu0z4whPsrvTAcu67iLlFmtvvrzopEI8Xj5qWk1pwMkj
+  skip_symbols: false
+  symbol_server: https://nuget.symbolsource.org/MyGet/snowflake-nightly
+  artifact: /.*\.nupkg/


### PR DESCRIPTION
Even if nuget push fails, the build will still succeed.