### PR TITLE
[BREAKING] Implement RangeMax and RangeMin for IConfigurationFlag (#45)

### DIFF
--- a/Snowflake.API/Emulator/Configuration/IConfigurationFlag.cs
+++ b/Snowflake.API/Emulator/Configuration/IConfigurationFlag.cs
@@ -26,6 +26,16 @@ namespace Snowflake.Emulator.Configuration
         /// </summary>
         IReadOnlyDictionary<string, string> SelectValues { get; }
         /// <summary>
+        /// The minimum value permitted if this is an INT_FLAG type
+        /// 0 if no minimum or not INT_FLAG
+        /// </summary>
+        int RangeMin { get; }
+        /// <summary>
+        /// The maximum value permitted if this is an INT_FLAG type
+        /// 0 if no maximum or not INT_FLAG
+        /// </summary>
+        int RangeMax { get; }
+        /// <summary>
         /// The type of configuration flag
         /// </summary>
         ConfigurationFlagTypes Type { get; }

--- a/Snowflake/Emulator/Configuration/ConfigurationFlag.cs
+++ b/Snowflake/Emulator/Configuration/ConfigurationFlag.cs
@@ -14,13 +14,18 @@ namespace Snowflake.Emulator.Configuration
         public ConfigurationFlagTypes Type { get; private set; }
         public string DefaultValue { get; private set; }
         public string Description { get; private set; }
+        public int RangeMin { get; private set; }
+        public int RangeMax { get; private set; }
         public IReadOnlyDictionary<string, string> SelectValues { get; private set; }
-        public ConfigurationFlag(string key, ConfigurationFlagTypes type, string defaultValue, string description, IDictionary<string, string> selectValues = null)
+        
+        public ConfigurationFlag(string key, ConfigurationFlagTypes type, string defaultValue, string description, int rangeMin = 0, int rangeMax = 0, IDictionary<string, string> selectValues = null)
         {
             this.Key = key;
             this.Type = type;
             this.DefaultValue = defaultValue;
             this.Description = description;
+            this.RangeMin = rangeMin;
+            this.RangeMax = rangeMax;
             if (selectValues != null)
             {
                 this.SelectValues = selectValues.AsReadOnly();
@@ -38,15 +43,19 @@ namespace Snowflake.Emulator.Configuration
                 throw new ArgumentException("type can be one of BOOLEAN_FLAG, INTEGER_FLAG, SELECT_FLAG. Fix your emulator plugin.");
             string description = protoTemplate["description"];
             string defaultValue = protoTemplate["default"].ToString();
+            dynamic max = 0;
+            dynamic min = 0;
+            dynamic selectTypes;
+            protoTemplate.TryGetValue("max", out max);
+            protoTemplate.TryGetValue("min", out min);
+            protoTemplate.TryGetValue("values", out selectTypes);
             try
             {
-                IDictionary<string, string> selectTypes = protoTemplate["values"].ToObject(typeof(IDictionary<string, string>));
-                return new ConfigurationFlag(key, type, defaultValue, description, selectTypes);
-
+                return new ConfigurationFlag(key, type, defaultValue, description, max, min, selectTypes.ToObject(typeof(IDictionary<string, string>)));
             }
-            catch (KeyNotFoundException)
+            catch (NullReferenceException)
             {
-                return new ConfigurationFlag(key, type, defaultValue, description);
+                return new ConfigurationFlag(key, type, defaultValue, description, max, min);
 
             }
         }

--- a/Snowflake/Emulator/Configuration/ConfigurationFlag.cs
+++ b/Snowflake/Emulator/Configuration/ConfigurationFlag.cs
@@ -51,13 +51,16 @@ namespace Snowflake.Emulator.Configuration
             protoTemplate.TryGetValue("values", out selectTypes);
             try
             {
-                return new ConfigurationFlag(key, type, defaultValue, description, max, min, selectTypes.ToObject(typeof(IDictionary<string, string>)));
+                selectTypes.ToObject(typeof(IDictionary<string, string>));
             }
             catch (NullReferenceException)
             {
-                return new ConfigurationFlag(key, type, defaultValue, description, max, min);
+                selectTypes = null;
 
             }
+            
+            return new ConfigurationFlag(key, type, defaultValue, description, max, min, selectTypes);
+
         }
     }
 }


### PR DESCRIPTION
This implements a maximum and minimum threshold for integer type configuration flags.