### PR TITLE
BREAKING Scraper: Parameterized Identifiers (#62)

### DIFF
--- a/Snowflake.API/Scraper/IScraper.cs
+++ b/Snowflake.API/Scraper/IScraper.cs
@@ -27,14 +27,14 @@ namespace Snowflake.Scraper
         /// </summary>
         /// <param name="searchQuery">The string to search</param>
         /// <param name="platformId">The Snowflake platform ID</param>
-        /// <returns></returns>
+        /// <returns>A list of search results</returns>
         IList<IGameScrapeResult> GetSearchResults(string searchQuery, string platformId);
         /// <summary>
         /// Gets the search results given a string query
         /// </summary>
         /// <param name="identifiedMetadata">The identified metadata gleaned from the ROM file</param>
         /// <param name="searchQuery">The string to search</param>
-        /// <returns></returns>
+        /// <returns>A list of search results</returns>
         IList<IGameScrapeResult> GetSearchResults(IDictionary<string, string> identifiedMetadata, string platformId);
         /// <summary>
         /// Gets the search results given a string query and the Snowflake platform ID of a platform
@@ -42,8 +42,16 @@ namespace Snowflake.Scraper
         /// <param name="identifiedMetadata">The identified metadata gleaned from the ROM file</param>
         /// <param name="searchQuery">The string to search</param>
         /// <param name="platformId">The Snowflake platform ID</param>
-        /// <returns></returns>
+        /// <returns>A list of search results</returns>
         IList<IGameScrapeResult> GetSearchResults(IDictionary<string, string> identifiedMetadata, string searchQuery, string platformId);
+        /// <summary>
+        /// Sorts the list of results from best match to worst match given the available metadata from
+        /// the game scrape results and the identified metadata for the game
+        /// </summary>
+        /// <param name="identifiedMetadata">The identified metadata gleaned from the ROM file</param>
+        /// <param name="searchResults">The search results to sort</param>
+        /// <returns>A sorted list of search results ordered from best to worst</returns>
+        IList<IGameScrapeResult> SortBestResults(IDictionary<string, string> identifiedMetadata, IList<IGameScrapeResult> searchResults);
         /// <summary>
         /// Gets the details of the games from the result id
         /// </summary>

--- a/Snowflake.API/Scraper/IScraper.cs
+++ b/Snowflake.API/Scraper/IScraper.cs
@@ -30,6 +30,21 @@ namespace Snowflake.Scraper
         /// <returns></returns>
         IList<IGameScrapeResult> GetSearchResults(string searchQuery, string platformId);
         /// <summary>
+        /// Gets the search results given a string query
+        /// </summary>
+        /// <param name="identifiedMetadata">The identified metadata gleaned from the ROM file</param>
+        /// <param name="searchQuery">The string to search</param>
+        /// <returns></returns>
+        IList<IGameScrapeResult> GetSearchResults(IDictionary<string, string> identifiedMetadata, string platformId);
+        /// <summary>
+        /// Gets the search results given a string query and the Snowflake platform ID of a platform
+        /// </summary>
+        /// <param name="identifiedMetadata">The identified metadata gleaned from the ROM file</param>
+        /// <param name="searchQuery">The string to search</param>
+        /// <param name="platformId">The Snowflake platform ID</param>
+        /// <returns></returns>
+        IList<IGameScrapeResult> GetSearchResults(IDictionary<string, string> identifiedMetadata, string searchQuery, string platformId);
+        /// <summary>
         /// Gets the details of the games from the result id
         /// </summary>
         /// <param name="id">Search Result ID</param>

--- a/Snowflake.Tests/Fakes/FakeScraper.cs
+++ b/Snowflake.Tests/Fakes/FakeScraper.cs
@@ -72,5 +72,21 @@ namespace Snowflake.Tests.Fakes
         {
             get { throw new NotImplementedException(); }
         }
+
+
+        public IList<Scraper.IGameScrapeResult> GetSearchResults(IDictionary<string, string> identifiedMetadata, string platformId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IList<Scraper.IGameScrapeResult> GetSearchResults(IDictionary<string, string> identifiedMetadata, string searchQuery, string platformId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IList<Scraper.IGameScrapeResult> SortBestResults(IDictionary<string, string> identifiedMetadata, IList<Scraper.IGameScrapeResult> searchResults)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Snowflake/Scraper/BaseScraper.cs
+++ b/Snowflake/Scraper/BaseScraper.cs
@@ -25,6 +25,9 @@ namespace Snowflake.Scraper
         }
         public abstract IList<IGameScrapeResult> GetSearchResults(string searchQuery);
         public abstract IList<IGameScrapeResult> GetSearchResults(string searchQuery, string platformId);
+        public abstract IList<IGameScrapeResult> GetSearchResults(IDictionary<string, string> identifiedMetadata, string platformId);
+        public abstract IList<IGameScrapeResult> GetSearchResults(IDictionary<string, string> identifiedMetadata, string searchQuery, string platformId);
+
         public abstract Tuple<IDictionary<string, string>, IGameImagesResult> GetGameDetails(string id);
 
     }

--- a/Snowflake/Scraper/BaseScraper.cs
+++ b/Snowflake/Scraper/BaseScraper.cs
@@ -27,7 +27,7 @@ namespace Snowflake.Scraper
         public abstract IList<IGameScrapeResult> GetSearchResults(string searchQuery, string platformId);
         public abstract IList<IGameScrapeResult> GetSearchResults(IDictionary<string, string> identifiedMetadata, string platformId);
         public abstract IList<IGameScrapeResult> GetSearchResults(IDictionary<string, string> identifiedMetadata, string searchQuery, string platformId);
-
+        public abstract IList<IGameScrapeResult> SortBestResults(IDictionary<string, string> identifiedMetadata, IList<IGameScrapeResult> searchResults);
         public abstract Tuple<IDictionary<string, string>, IGameImagesResult> GetGameDetails(string id);
 
     }


### PR DESCRIPTION
Provides extensions to the IScraper interface to allow for paramterized identifier metadata scrape queries. 