### PR TITLE
Build: Add and publish nupkgs for Events, InputManager and Tests

### DIFF
--- a/Snowflake.API/Snowflake.API.nuspec
+++ b/Snowflake.API/Snowflake.API.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/SnowflakePowered/snowflake</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/SnowflakePowered/snowflake/master/branding/Snowflake-Ring-128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>"Snowflake API C# Interfaces Library"</description>
+    <description>Snowflake API C# Interface Library</description>
     <copyright>Copyright Ronny Chan 2015</copyright>
     <tags>Snowflake Emulator Frontend</tags>
   </metadata>

--- a/Snowflake.Events/Snowflake.Events.nuspec
+++ b/Snowflake.Events/Snowflake.Events.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/SnowflakePowered/snowflake</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/SnowflakePowered/snowflake/master/branding/Snowflake-Ring-128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Snowflake C# API Implementation Library</description>
+    <description>Snowflake C# API Events Framework</description>
     <copyright>Copyright Ronny Chan 2015</copyright>
     <tags>Snowflake Emulator Frontend</tags>
   </metadata>

--- a/Snowflake.InputManager.DirectInput/Snowflake.InputManager.DirectInput.nuspec
+++ b/Snowflake.InputManager.DirectInput/Snowflake.InputManager.DirectInput.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/SnowflakePowered/snowflake</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/SnowflakePowered/snowflake/master/branding/Snowflake-Ring-128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Snowflake C# API Implementation Library</description>
+    <description>Snowflake InputManager helper (DirectInput)</description>
     <copyright>Copyright Ronny Chan 2015</copyright>
     <tags>Snowflake Emulator Frontend</tags>
   </metadata>

--- a/Snowflake.Tests/Properties/AssemblyInfo.cs
+++ b/Snowflake.Tests/Properties/AssemblyInfo.cs
@@ -8,9 +8,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Snowflake.Tests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Snowflake.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -21,16 +18,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f3352a7e-d31c-42c7-864a-af4cdf594b94")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Snowflake.Tests/Snowflake.Tests.csproj
+++ b/Snowflake.Tests/Snowflake.Tests.csproj
@@ -65,6 +65,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Controller\ControllerDefinitionTests.cs" />
     <Compile Include="Controller\ControllerProfileTests.cs" />
     <Compile Include="Events\SnowflakeEventSourceTests.cs" />

--- a/Snowflake.Tests/Snowflake.Tests.nuspec
+++ b/Snowflake.Tests/Snowflake.Tests.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/SnowflakePowered/snowflake</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/SnowflakePowered/snowflake/master/branding/Snowflake-Ring-128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Snowflake C# API Implementation Library</description>
+    <description>Snowflake C# API Unit Tests</description>
     <copyright>Copyright Ronny Chan 2015</copyright>
     <tags>Snowflake Emulator Frontend</tags>
   </metadata>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ branches:
   only:
     - master
 skip_tags: true
+clone_depth: 50
 test:
   assemblies:
     - Snowflake.Test.dll
@@ -28,23 +29,38 @@ after_test:
     - echo Uploading Code Coverage Report to Coveralls
     - packages\coveralls.io.1.1.86\tools\coveralls.net.exe --opencover coverage.xml
     - echo Packing NuGet packages
+    - nuget pack Snowflake.API\Snowflake.API.csproj -IncludeReferencedProjects -Symbols
+    - nuget pack Snowflake.Events\Snowflake.Events.csproj -IncludeReferencedProjects -Symbols
     - nuget pack Snowflake\Snowflake.csproj -IncludeReferencedProjects -Symbols
-    - nuget pack Snowflake.API\Snowflake.API.csproj -IncludeReferencedProjects  -Symbols
+    - nuget pack Snowflake.InputManager.DirectInput\Snowflake.InputManager.DirectInput.csproj -IncludeReferencedProjects -Symbols
+    - nuget pack Snowflake.Tests\Snowflake.Tests.csproj -IncludeReferencedProjects -Symbols
 artifacts:
     - path: Snowflake\bin\$(configuration)
       name: Snowflake Base Libraries
       type: zip
     - path: doc
-      name: Generated documentation
+      name: Generated doxygen documentation
       type: zip
     - path: 'Snowflake\Snowflake.{version}-pre-alpha-nightly.nupkg'
       name: Snowflake NuGet Packages
     - path: 'Snowflake.API\Snowflake.API.{version}-pre-alpha-nightly.nupkg'
       name: Snowflake.API NuGet Packages
+    - path: 'Snowflake.Events\Snowflake.Events.{version}-pre-alpha-nightly.nupkg'
+      name: Snowflake.Events NuGet Packages
+    - path: 'Snowflake.InputManager.DirectInput\Snowflake.InputManager.DirectInput.{version}-pre-alpha-nightly.nupkg'
+      name: Snowflake.InputManager.DirectInput NuGet Packages
+    - path: 'Snowflake.Tests\Snowflake.Tests.{version}-pre-alpha-nightly.nupkg'
+      name: Snowflake.Tests NuGet Packages
     - path: 'Snowflake\Snowflake.{version}-pre-alpha-nightly.symbols.nupkg'
       name: Snowflake NuGet Packages
     - path: 'Snowflake.API\Snowflake.API.{version}-pre-alpha-nightly.symbols.nupkg'
       name: Snowflake.API NuGet Packages
+    - path: 'Snowflake.Events\Snowflake.Events.{version}-pre-alpha-nightly.symbols.nupkg'
+      name: Snowflake.Events NuGet Packages
+    - path: 'Snowflake.InputManager.DirectInput\Snowflake.InputManager.DirectInput.{version}-pre-alpha-nightly.symbols.nupkg'
+      name: Snowflake.InputManager.DirectInput NuGet Packages
+    - path: 'Snowflake.Tests\Snowflake.Tests.{version}-pre-alpha-nightly.symbols.nupkg'
+      name: Snowflake.Tests NuGet Packages
 assembly_info:
     patch: true
     file: SharedAssemblyInfo.cs


### PR DESCRIPTION
The Events, InputManager and Tests assemblies will be published to the MyGet feed as part of the appveyor build process.