### PR TITLE
JSAPI: Implement required Javascript Parameters and JSON response metadata

### DIFF
--- a/Snowflake.API/Ajax/AjaxMethodParameterAttribute.cs
+++ b/Snowflake.API/Ajax/AjaxMethodParameterAttribute.cs
@@ -13,8 +13,16 @@ namespace Snowflake.Ajax
     [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
     public class AjaxMethodParameterAttribute : Attribute
     {
+        //The name of the parameter
         public string ParameterName { get; set; }
+        /// <summary>
+        /// The type of parameter
+        /// </summary>
         public AjaxMethodParameterType ParameterType { get; set; }
+        /// <summary>
+        /// Whether the parameter is required
+        /// </summary>
+        public bool Required { get; set; }
     }
     public enum AjaxMethodParameterType
     {

--- a/Snowflake.API/Ajax/IBaseAjaxNamespace.cs
+++ b/Snowflake.API/Ajax/IBaseAjaxNamespace.cs
@@ -18,6 +18,6 @@ namespace Snowflake.Ajax
         /// <summary>
         /// The generated dictionary of Javascript Methods
         /// </summary>
-        IDictionary<string, Func<IJSRequest, IJSResponse>> JavascriptMethods { get; }
+        IDictionary<string, IJSMethod> JavascriptMethods { get; }
     }
 }

--- a/Snowflake.API/Ajax/IJSMethod.cs
+++ b/Snowflake.API/Ajax/IJSMethod.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection;
+
+namespace Snowflake.Ajax
+{
+    public interface IJSMethod
+    {
+        MethodInfo MethodInfo { get; }
+        Func<IJSRequest, IJSResponse> Method { get; }
+    }
+}

--- a/Snowflake.API/Snowflake.API.csproj
+++ b/Snowflake.API/Snowflake.API.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Ajax\AjaxMethodAttribute.cs" />
     <Compile Include="Ajax\AjaxMethodParameterAttribute.cs" />
     <Compile Include="Ajax\IBaseAjaxNamespace.cs" />
+    <Compile Include="Ajax\IJSMethod.cs" />
     <Compile Include="Ajax\IJSRequest.cs" />
     <Compile Include="Ajax\IJSResponse.cs" />
     <Compile Include="Emulator\Input\InputManager\InputDeviceNames.cs" />

--- a/Snowflake.Service/Service/Manager/AjaxManager.cs
+++ b/Snowflake.Service/Service/Manager/AjaxManager.cs
@@ -37,7 +37,15 @@ namespace Snowflake.Service.Manager
         {
             try
             {
-                IJSResponse result = this.GlobalNamespace[request.NameSpace].JavascriptMethods[request.MethodName].Method.Invoke(request);
+                IJSResponse result;
+                IJSMethod jsMethod = this.GlobalNamespace[request.NameSpace].JavascriptMethods[request.MethodName];
+                foreach (AjaxMethodParameterAttribute attr in jsMethod.MethodInfo.GetCustomAttributes<AjaxMethodParameterAttribute>().Where(attr => attr.Required = true))
+                {
+                    result = new JSResponse(request, new Dictionary<string, string>() { { "error", String.Format("missing required param {0}", attr.ParameterName) } }, false);
+                    return result.GetJson();
+                }
+
+                result = jsMethod.Method.Invoke(request);
                 return result.GetJson();
             }
             catch (Exception e)

--- a/Snowflake.Service/Service/Manager/AjaxManager.cs
+++ b/Snowflake.Service/Service/Manager/AjaxManager.cs
@@ -37,7 +37,7 @@ namespace Snowflake.Service.Manager
         {
             try
             {
-                IJSResponse result = this.GlobalNamespace[request.NameSpace].JavascriptMethods[request.MethodName].Invoke(request);
+                IJSResponse result = this.GlobalNamespace[request.NameSpace].JavascriptMethods[request.MethodName].Method.Invoke(request);
                 return result.GetJson();
             }
             catch (Exception e)

--- a/Snowflake/Ajax/JSMethod.cs
+++ b/Snowflake/Ajax/JSMethod.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection;
+namespace Snowflake.Ajax
+{
+    internal sealed class JSMethod : IJSMethod
+    {
+        public MethodInfo MethodInfo { get; private set; }
+        public Func<IJSRequest, IJSResponse> Method { get; private set; }
+        public JSMethod(MethodInfo methodInfo, Func<IJSRequest, IJSResponse> method)
+        {
+            this.Method = method;
+            this.MethodInfo = methodInfo;
+        }
+    }
+}

--- a/Snowflake/Ajax/JSResponse.cs
+++ b/Snowflake/Ajax/JSResponse.cs
@@ -28,15 +28,19 @@ namespace Snowflake.Ajax
             if (request.MethodParameters.ContainsKey("jsoncallback"))
             {
                 return request.MethodParameters["jsoncallback"] + "(" + JsonConvert.SerializeObject(new Dictionary<string, object>(){
+                    {"request", request},
                     {"payload", output},
-                    {"success", success}
+                    {"success", success},
+                    {"type", "methodresponse"}
                 }) + ");";
             }
             else
             {
                 return JsonConvert.SerializeObject(new Dictionary<string, object>(){
+                    {"request", request},
                     {"payload", output},
-                    {"success", success}
+                    {"success", success},
+                    {"type", "methodresponse"}
                 });
             }
         }

--- a/Snowflake/Snowflake.csproj
+++ b/Snowflake/Snowflake.csproj
@@ -82,6 +82,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Ajax\BaseAjaxNamespace.cs" />
+    <Compile Include="Ajax\JSMethod.cs" />
     <Compile Include="Ajax\JSRequest.cs" />
     <Compile Include="Ajax\JSResponse.cs" />
     <Compile Include="Controller\ControllerProfileStore.cs" />


### PR DESCRIPTION
This adds the 'request' and 'type' keys in the JSON body. The request is the IJSRequest that prompted the reply, and the type key indicates that the response was prompted from calling a method. 

This works in conjunction with #75 by allowing types of JS messages other than the result of a method call.