### PR TITLE
StandardAjax: Pass raw game info json instead of encoded

### DIFF
--- a/Snowflake.StandardAjax/StandardAjax.Game.cs
+++ b/Snowflake.StandardAjax/StandardAjax.Game.cs
@@ -38,11 +38,11 @@ namespace Snowflake.StandardAjax
         }
 
         [AjaxMethod(MethodPrefix = "Game")]
-        [AjaxMethodParameter(ParameterName = "enc_gameinfo", ParameterType = AjaxMethodParameterType.ObjectParameter)]
+        [AjaxMethodParameter(ParameterName = "gameinfo", ParameterType = AjaxMethodParameterType.ObjectParameter)]
         public IJSResponse AddGameInfo(IJSRequest request)
         {
-            string gameinfo_pre = request.GetParameter("enc_gameinfo");
-            IGameInfo game = JsonConvert.DeserializeObject<GameInfo>(StringEncode.atob(gameinfo_pre));
+            string gameinfo_pre = request.GetParameter("gameinfo");
+            IGameInfo game = JsonConvert.DeserializeObject<GameInfo>(gameinfo_pre);
             this.CoreInstance.GameDatabase.AddGame(game);
             return new JSResponse(request, "added " + game.FileName, true);
         }

--- a/Snowflake.StandardAjax/StandardAjax.Game.cs
+++ b/Snowflake.StandardAjax/StandardAjax.Game.cs
@@ -42,7 +42,7 @@ namespace Snowflake.StandardAjax
         public IJSResponse AddGameInfo(IJSRequest request)
         {
             string gameinfo_pre = request.GetParameter("enc_gameinfo");
-            IGameInfo game = JsonConvert.DeserializeObject<GameInfo>(StringEncode.btoa(gameinfo_pre));
+            IGameInfo game = JsonConvert.DeserializeObject<GameInfo>(StringEncode.atob(gameinfo_pre));
             this.CoreInstance.GameDatabase.AddGame(game);
             return new JSResponse(request, "added " + game.FileName, true);
         }


### PR DESCRIPTION
If the game info contains unicode characters, the encoding will fail. Therefore, simply pass the raw, unencoded json as a parameter.