### PR TITLE
Normalize references to 'Id' to 'ID'

### DIFF
--- a/Platforms/NINTENDO_NES.platform
+++ b/Platforms/NINTENDO_NES.platform
@@ -1,5 +1,5 @@
 {
-    "PlatformId": "NINTENDO_NES",
+    "PlatformID": "NINTENDO_NES",
     "Name": "Nintendo Entertainment System",
     "MediaStoreKey": "platform.NINTENDO_NES",
     "FileExtensions": [

--- a/Platforms/NINTENDO_SNES.platform
+++ b/Platforms/NINTENDO_SNES.platform
@@ -1,5 +1,5 @@
 {
-    "PlatformId": "NINTENDO_SNES",
+    "PlatformID": "NINTENDO_SNES",
     "Name": "Super Nintendo Entertainment System",
     "MediaStoreKey": "platform.NINTENDO_SNES",
     "FileExtensions": [

--- a/Snowflake.API/Emulator/IEmulatorAssembly.cs
+++ b/Snowflake.API/Emulator/IEmulatorAssembly.cs
@@ -15,7 +15,7 @@ namespace Snowflake.Emulator
         /// <summary>
         /// The ID that emulator bridges can refer to 
         /// </summary>
-        string EmulatorId { get; }
+        string EmulatorID { get; }
         /// <summary>
         /// The name of this emulator
         /// </summary>

--- a/Snowflake.API/Information/IInfo.cs
+++ b/Snowflake.API/Information/IInfo.cs
@@ -13,7 +13,7 @@ namespace Snowflake.Information
         /// <summary>
         /// The id of the platform that this object is related to
         /// </summary>
-        string PlatformId { get; }
+        string PlatformID { get; }
         /// <summary>
         /// The name of this object
         /// </summary>

--- a/Snowflake.Service/Service/CoreService.cs
+++ b/Snowflake.Service/Service/CoreService.cs
@@ -104,7 +104,7 @@ namespace Snowflake.Service
                 {
                     var _platform = JsonConvert.DeserializeObject<IDictionary<string, dynamic>>(File.ReadAllText(fileName));
                     var platform = PlatformInfo.FromJsonProtoTemplate(_platform); //Convert MediaStoreKey reference to full MediaStore object
-                    loadedPlatforms.Add(platform.PlatformId, platform);
+                    loadedPlatforms.Add(platform.PlatformID, platform);
                 }
                 catch (Exception)
                 {

--- a/Snowflake.Service/Service/Manager/EmulatorAssembliesManager.cs
+++ b/Snowflake.Service/Service/Manager/EmulatorAssembliesManager.cs
@@ -28,11 +28,11 @@ namespace Snowflake.Service.Manager
                 if (!(Path.GetExtension(fileName) == ".yml")) continue;
                 
                 var emulatorCore = EmulatorAssembliesManager.ParseEmulatorAssembly(fileName);
-                this.emulatorAssemblies.Add(emulatorCore.EmulatorId, emulatorCore);
+                this.emulatorAssemblies.Add(emulatorCore.EmulatorID, emulatorCore);
             }
         }
         public string GetAssemblyDirectory(IEmulatorAssembly assembly){
-            return Path.Combine(this.AssembliesLocation, assembly.EmulatorId);
+            return Path.Combine(this.AssembliesLocation, assembly.EmulatorID);
         }
         public static IEmulatorAssembly ParseEmulatorAssembly(string emulatorCorePath)
         {

--- a/Snowflake.Service/Service/ScrapeService.cs
+++ b/Snowflake.Service/Service/ScrapeService.cs
@@ -28,14 +28,14 @@ namespace Snowflake.Service
         public IList<IGameScrapeResult> GetGameResults(string fileName)
         {
             IDictionary<string, string> identifiedMetadata = CoreService.LoadedCore.PluginManager.LoadedIdentifiers.Values
-                .Where(identifier => identifier.SupportedPlatforms.Contains(this.ScrapePlatform.PlatformId))
+                .Where(identifier => identifier.SupportedPlatforms.Contains(this.ScrapePlatform.PlatformID))
                 .ToDictionary(identifier => identifier.PluginName,
-                    identifier => identifier.IdentifyGame(fileName, this.ScrapePlatform.PlatformId));
+                    identifier => identifier.IdentifyGame(fileName, this.ScrapePlatform.PlatformID));
             identifiedMetadata["md5"] = FileHash.GetMD5(fileName);
             identifiedMetadata["crc32"] = FileHash.GetCRC32(fileName);
             identifiedMetadata["sha1"] = FileHash.GetSHA1(fileName);
             identifiedMetadata["filename"] = fileName; 
-            return this.ScraperPlugin.SortBestResults(identifiedMetadata, this.ScraperPlugin.GetSearchResults(identifiedMetadata, this.ScrapePlatform.PlatformId));
+            return this.ScraperPlugin.SortBestResults(identifiedMetadata, this.ScraperPlugin.GetSearchResults(identifiedMetadata, this.ScrapePlatform.PlatformID));
 
         }
 
@@ -50,7 +50,7 @@ namespace Snowflake.Service
             var gameinfo = resultdetails.Item1;
             var gameUuid = FileHash.GetMD5(fileName);
             return new GameInfo(
-                this.ScrapePlatform.PlatformId,
+                this.ScrapePlatform.PlatformID,
                 gameinfo[GameInfoFields.game_title],
                 resultdetails.Item2.ToMediaStore("game." + ScrapeService.ValidateFilename(gameinfo[GameInfoFields.game_title]).Replace(' ', '_') + gameUuid),
                 gameinfo,

--- a/Snowflake.StandardAjax/StandardAjax.Game.cs
+++ b/Snowflake.StandardAjax/StandardAjax.Game.cs
@@ -76,9 +76,9 @@ namespace Snowflake.StandardAjax
             IDictionary<string, List<IGameInfo>> sortedGames = this.CoreInstance.LoadedPlatforms.ToDictionary(platform => platform.Key, platform => new List<IGameInfo>());
             foreach(IGameInfo game in games)
             {
-                if (sortedGames.ContainsKey(game.PlatformId))
+                if (sortedGames.ContainsKey(game.PlatformID))
                 {
-                    sortedGames[game.PlatformId].Add(game);
+                    sortedGames[game.PlatformID].Add(game);
                 }
             }
             return new JSResponse(request, sortedGames);

--- a/Snowflake.Tests/Fakes/FakeEmulatorAssembly.cs
+++ b/Snowflake.Tests/Fakes/FakeEmulatorAssembly.cs
@@ -13,7 +13,7 @@ namespace Snowflake.Tests.Fakes
             get { throw new NotImplementedException(); }
         }
 
-        public string EmulatorId
+        public string EmulatorID
         {
             get { throw new NotImplementedException(); }
         }

--- a/Snowflake.Tests/Fakes/FakeGameInfo.cs
+++ b/Snowflake.Tests/Fakes/FakeGameInfo.cs
@@ -23,7 +23,7 @@ namespace Snowflake.Tests.Fakes
             get { throw new NotImplementedException(); }
         }
 
-        public string PlatformId
+        public string PlatformID
         {
             get { throw new NotImplementedException(); }
         }

--- a/Snowflake.Tests/Fakes/FakePlatformInfo.cs
+++ b/Snowflake.Tests/Fakes/FakePlatformInfo.cs
@@ -41,7 +41,7 @@ namespace Snowflake.Tests.Fakes
             get { throw new NotImplementedException(); }
         }
 
-        public string PlatformId
+        public string PlatformID
         {
             get { throw new NotImplementedException(); }
         }

--- a/Snowflake.Tests/Platform/PlatformInfoTests.cs
+++ b/Snowflake.Tests/Platform/PlatformInfoTests.cs
@@ -28,7 +28,7 @@ namespace Snowflake.Platform.Tests
             string platformDefinition = TestUtilities.GetStringResource("Platforms." + platformId + ".platform");
             var protoTemplate = JsonConvert.DeserializeObject<IDictionary<string, dynamic>>(platformDefinition);
             var platform = PlatformInfo.FromJsonProtoTemplate(protoTemplate);
-            Assert.Equal(platformId, platform.PlatformId);
+            Assert.Equal(platformId, platform.PlatformID);
         }
 
         public static IEnumerable<object[]> TestedPlatforms

--- a/Snowflake/Controller/ControllerPortsDatabase.cs
+++ b/Snowflake/Controller/ControllerPortsDatabase.cs
@@ -51,7 +51,7 @@ namespace Snowflake.Controller
                                                                 null
                                                                 )", this.DBConnection))
             {
-                sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformId);
+                sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformID);
                 sqlCommand.ExecuteNonQuery();
                 this.DBConnection.Close();
             }/*
@@ -74,7 +74,7 @@ namespace Snowflake.Controller
             using (var sqlCommand = new SQLiteCommand("SELECT `%portNumber` FROM `ports` WHERE `platform_id` == @platformId", this.DBConnection))
             {
                 sqlCommand.CommandText = sqlCommand.CommandText.Replace("%portNumber", "port"+portNumber);
-                sqlCommand.Parameters.AddWithValue("@platformId", platformInfo.PlatformId);
+                sqlCommand.Parameters.AddWithValue("@platformId", platformInfo.PlatformID);
                 using (var reader = sqlCommand.ExecuteReader())
                 {
                     var result = new DataTable();
@@ -97,7 +97,7 @@ namespace Snowflake.Controller
             {
                 sqlCommand.CommandText = sqlCommand.CommandText.Replace("%portNumber", "port" + portNumber);
                 sqlCommand.Parameters.AddWithValue("@controllerId", deviceName);
-                sqlCommand.Parameters.AddWithValue("@platformId", platformInfo.PlatformId);
+                sqlCommand.Parameters.AddWithValue("@platformId", platformInfo.PlatformID);
                 sqlCommand.ExecuteNonQuery();
             }
             this.DBConnection.Close();

--- a/Snowflake/Emulator/EmulatorAssembly.cs
+++ b/Snowflake/Emulator/EmulatorAssembly.cs
@@ -10,7 +10,7 @@ namespace Snowflake.Emulator
     public class EmulatorAssembly : IEmulatorAssembly
     {
         public string MainAssembly { get; private set; }
-        public string EmulatorId { get; private set; }
+        public string EmulatorID { get; private set; }
         public string EmulatorName { get; private set; }
         public EmulatorAssemblyType AssemblyType { get; private set; }
 
@@ -19,7 +19,7 @@ namespace Snowflake.Emulator
             EmulatorAssemblyType assemblyType;
             if (!Enum.TryParse<EmulatorAssemblyType>(assemblyTypeString, true, out assemblyType)) assemblyType = EmulatorAssemblyType.EMULATOR_MISC;
             this.MainAssembly = mainAssembly;
-            this.EmulatorId = emulatorId;
+            this.EmulatorID = emulatorId;
             this.EmulatorName = name;
             this.AssemblyType = assemblyType;
         }
@@ -27,7 +27,7 @@ namespace Snowflake.Emulator
         public EmulatorAssembly(string mainAssembly, string emulatorId, string name, EmulatorAssemblyType assemblyType)
         {
             this.MainAssembly = mainAssembly;
-            this.EmulatorId = emulatorId;
+            this.EmulatorID = emulatorId;
             this.EmulatorName = name;
             this.AssemblyType = assemblyType;
         }

--- a/Snowflake/Game/GameDatabase.cs
+++ b/Snowflake/Game/GameDatabase.cs
@@ -50,7 +50,7 @@ namespace Snowflake.Game
                                           @metadata,
                                           @crc32)", this.DBConnection))
             {
-                sqlCommand.Parameters.AddWithValue("@platform_id", game.PlatformId);
+                sqlCommand.Parameters.AddWithValue("@platform_id", game.PlatformID);
                 sqlCommand.Parameters.AddWithValue("@uuid", game.UUID);
                 sqlCommand.Parameters.AddWithValue("@filename", game.FileName);
                 sqlCommand.Parameters.AddWithValue("@name", game.Name);

--- a/Snowflake/Information/Info.cs
+++ b/Snowflake/Information/Info.cs
@@ -5,14 +5,14 @@ namespace Snowflake.Information
 {
     public class Info: IInfo
     {
-        public string PlatformId { get; private set; }
+        public string PlatformID { get; private set; }
         public string Name { get; private set; }
         public IMediaStore MediaStore { get; private set; }
         public IDictionary<string, string> Metadata { get; set; }
 
         public Info(string platformId, string name, IMediaStore mediastore, IDictionary<string,string> metadata)
         {
-            this.PlatformId = platformId;
+            this.PlatformID = platformId;
             this.Name = name;
             this.MediaStore = mediastore;
             this.Metadata = metadata;

--- a/Snowflake/Platform/PlatformInfo.cs
+++ b/Snowflake/Platform/PlatformInfo.cs
@@ -33,7 +33,7 @@ namespace Snowflake.Platform
             IPlatformDefaults platformDefaults = jsonDictionary["Defaults"].ToObject<PlatformDefaults>();
 
             return new PlatformInfo(
-                    jsonDictionary["PlatformId"],
+                    jsonDictionary["PlatformID"],
                     jsonDictionary["Name"],
                     new FileMediaStore(jsonDictionary["MediaStoreKey"]),
                     jsonDictionary["Metadata"].ToObject<Dictionary<string, string>>(),

--- a/Snowflake/Platform/PlatformPreferencesDatabase.cs
+++ b/Snowflake/Platform/PlatformPreferencesDatabase.cs
@@ -36,7 +36,7 @@ namespace Snowflake.Platform
                                           @scraper,
                                           @identifier)", this.DBConnection))
             {
-                sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformId);
+                sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformID);
                 sqlCommand.Parameters.AddWithValue("@emulator", platformInfo.Defaults.Emulator);
                 sqlCommand.Parameters.AddWithValue("@scraper", platformInfo.Defaults.Scraper);
                 sqlCommand.Parameters.AddWithValue("@identifier", platformInfo.Defaults.Identifier);
@@ -51,7 +51,7 @@ namespace Snowflake.Platform
             using (var sqlCommand = new SQLiteCommand(@"SELECT * FROM `platformprefs` WHERE `platform_id` == @platform_id"
                 , this.DBConnection))
             {
-                sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformId);
+                sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformID);
                 using (var reader = sqlCommand.ExecuteReader())
                 {
                     var result = new DataTable();
@@ -88,7 +88,7 @@ namespace Snowflake.Platform
                 sqlCommand.CommandText = sqlCommand.CommandText.Replace("%colName", column);
 
                 sqlCommand.Parameters.AddWithValue("@value", value);
-                sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformId);
+                sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformID);
                 sqlCommand.ExecuteNonQuery();
             }
             this.DBConnection.Close();


### PR DESCRIPTION
This renames all UpperCamelCased references including the string 'Id' to 'ID'. 

> An I.D. (identifier) property or variable name shall use the form 'ID' if the name is UpperCamelCased according to other conventions. If the name of the property or variable is in the local scope and thus is lowerCamelCased, the name shall use the form 'Id'. 