### PR TITLE
[WIP] BREAKING CoreService: Abstract away servers in a collection (#92)

### DIFF
--- a/Snowflake.API/Service/HttpServer/BaseHttpServer.cs
+++ b/Snowflake.API/Service/HttpServer/BaseHttpServer.cs
@@ -19,7 +19,7 @@ namespace Snowflake.Service.HttpServer
             serverListener = new HttpListener();
             serverListener.Prefixes.Add("http://localhost:" + port.ToString() + "/");
         }
-        public void StartServer()
+        void IBaseHttpServer.StartServer()
         {
             this.serverThread = new Thread(
                 () =>
@@ -36,7 +36,7 @@ namespace Snowflake.Service.HttpServer
             this.serverThread.Start();
         }
 
-        public void StopServer()
+        void IBaseHttpServer.StopServer()
         {
             this.cancel = true;
             this.serverThread.Join();

--- a/Snowflake.API/Service/ICoreService.cs
+++ b/Snowflake.API/Service/ICoreService.cs
@@ -19,14 +19,6 @@ namespace Snowflake.Service
         /// </summary>
         IAjaxManager AjaxManager { get; }
         /// <summary>
-        /// The Ajax API server
-        /// </summary>
-        IBaseHttpServer APIServer { get; }
-        /// <summary>
-        /// The WebSocket API server
-        /// </summary>
-        IJSWebSocketServer APIWebSocketServer { get; }
-        /// <summary>
         /// The Emulator assemblies manager
         /// </summary>
         IEmulatorAssembliesManager EmulatorManager { get; }
@@ -55,16 +47,12 @@ namespace Snowflake.Service
         /// </summary>
         IDictionary<string, IControllerDefinition> LoadedControllers { get; }
         /// <summary>
-        /// The server that servers mediastore requests
-        /// </summary>
-        IBaseHttpServer MediaStoreServer { get; }
-        /// <summary>
         /// The plugin manager
         /// </summary>
         IPluginManager PluginManager { get; }
         /// <summary>
-        /// The server thats serves themes
+        /// The webserver manager
         /// </summary>
-        IBaseHttpServer ThemeServer { get; }
+        IServerManager ServerManager { get; }
     }
 }

--- a/Snowflake.API/Service/JSWebSocketServer/IJSWebSocketServer.cs
+++ b/Snowflake.API/Service/JSWebSocketServer/IJSWebSocketServer.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using Snowflake.Service.HttpServer;
 namespace Snowflake.Service.JSWebSocketServer
 {
     /// <summary>
     /// Represents a web socket server for 2 way duplex communication
     /// </summary>
-    public interface IJSWebSocketServer
+    public interface IJSWebSocketServer : IBaseHttpServer
     {
         /// <summary>
         /// Send a message to all connected clients
@@ -23,9 +24,5 @@ namespace Snowflake.Service.JSWebSocketServer
         /// When a new socket connection has opened
         /// </summary>
         event EventHandler<SocketConnectionEventArgs> SocketOpen;
-        /// <summary>
-        /// Start the WebSocketServer on a new thread
-        /// </summary>
-        void StartServer();
     }
 }

--- a/Snowflake.API/Service/Manager/IServerManager.cs
+++ b/Snowflake.API/Service/Manager/IServerManager.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Snowflake.Service.HttpServer;
+namespace Snowflake.Service.Manager
+{
+    public interface IServerManager
+    {
+        public void RegisterServer(string serverName, IBaseHttpServer httpServer);
+        public void StartServer(string serverName);
+        public void StopServer(string serverName);
+        public IList<string> RegisteredServers { get; }
+    }
+}

--- a/Snowflake.API/Service/Manager/IServerManager.cs
+++ b/Snowflake.API/Service/Manager/IServerManager.cs
@@ -8,9 +8,9 @@ namespace Snowflake.Service.Manager
 {
     public interface IServerManager
     {
-        public void RegisterServer(string serverName, IBaseHttpServer httpServer);
-        public void StartServer(string serverName);
-        public void StopServer(string serverName);
-        public IList<string> RegisteredServers { get; }
+        void RegisterServer(string serverName, IBaseHttpServer httpServer);
+        void StartServer(string serverName);
+        void StopServer(string serverName);
+        IList<string> RegisteredServers { get; }
     }
 }

--- a/Snowflake.API/Service/Manager/IServerManager.cs
+++ b/Snowflake.API/Service/Manager/IServerManager.cs
@@ -12,5 +12,7 @@ namespace Snowflake.Service.Manager
         void StartServer(string serverName);
         void StopServer(string serverName);
         IList<string> RegisteredServers { get; }
+        IBaseHttpServer GetServer(string serverName);
+        IBaseHttpServer this[string serverName] { get; }
     }
 }

--- a/Snowflake.API/Snowflake.API.csproj
+++ b/Snowflake.API/Snowflake.API.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Service\Manager\ILoadableManager.cs" />
     <Compile Include="Service\Manager\IPluginManager.cs" />
     <Compile Include="Service\JSWebSocketServer\JSWebSocketServerEventArgs.cs" />
+    <Compile Include="Service\Manager\IServerManager.cs" />
     <Compile Include="Utility\BaseDatabase.cs" />
     <Compile Include="Utility\BiDictionary.cs" />
     <Compile Include="Utility\FileHash.cs" />

--- a/Snowflake.Core.Init/Form1.cs
+++ b/Snowflake.Core.Init/Form1.cs
@@ -29,19 +29,17 @@ using Snowflake.Emulator.Input.Constants;
 using Snowflake.Emulator;
 using Snowflake.Utility;
 using Snowflake.Service.JSWebSocketServer;
+using Snowflake.Service.HttpServer;
 using Fleck;
 namespace Snowflake.Service.Init
 {
     public partial class Form1 : Form
     {
-        JsonApiWebSocketServer server;
         static CoreService fcRef;
         public Form1()
         {
             InitializeComponent();
             Console.SetOut(new MultiTextWriter(new ControlWriter(this.textBox1, this), Console.Out));
-            server = new JsonApiWebSocketServer(8181);
-            server.StartServer();
             start();
  string x_ = @"
 [
@@ -164,7 +162,6 @@ namespace Snowflake.Service.Init
 
         private void button1_Click(object sender, EventArgs e)
         {
-            server.SendMessage("I AM TEST");
         }
     }
     //http://stackoverflow.com/questions/18726852/redirecting-console-writeline-to-textbox

--- a/Snowflake.Events/ServiceEvents/ServerStartEventArgs.cs
+++ b/Snowflake.Events/ServiceEvents/ServerStartEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Snowflake.Service;
+
+namespace Snowflake.Events.ServiceEvents
+{
+    public class ServerStartEventArgs: SnowflakeEventArgs
+    {
+        public ServerStartEventArgs(ICoreService eventCoreInstance)
+            : base(eventCoreInstance)
+        {
+            
+        }
+    }
+}

--- a/Snowflake.Events/ServiceEvents/ServerStopEventArgs.cs
+++ b/Snowflake.Events/ServiceEvents/ServerStopEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Snowflake.Service;
+
+namespace Snowflake.Events.ServiceEvents
+{
+    public class ServerStopEventArgs : SnowflakeEventArgs
+    {
+        public ServerStopEventArgs(ICoreService eventCoreInstance)
+            : base(eventCoreInstance)
+        {
+
+        }
+    }
+}

--- a/Snowflake.Events/Snowflake.Events.csproj
+++ b/Snowflake.Events/Snowflake.Events.csproj
@@ -64,6 +64,8 @@
     <Compile Include="ServiceEvents\CoreLoadedEventArgs.cs" />
     <Compile Include="ServiceEvents\CoreShutdownEventArgs.cs" />
     <Compile Include="ServiceEvents\EmulatorPromptEventArgs.cs" />
+    <Compile Include="ServiceEvents\ServerStartEventArgs.cs" />
+    <Compile Include="ServiceEvents\ServerStopEventArgs.cs" />
     <Compile Include="SnowflakeEventArgs.cs" />
     <Compile Include="SnowflakeEventSource.cs" />
     <Compile Include="SnowflakeEventSource.Game.cs" />

--- a/Snowflake.Events/SnowflakeEventSource.ServiceEvents.cs
+++ b/Snowflake.Events/SnowflakeEventSource.ServiceEvents.cs
@@ -13,6 +13,8 @@ namespace Snowflake.Events
         public event EventHandler<CoreLoadedEventArgs> CoreLoaded;
         public event EventHandler<CoreShutdownEventArgs> CoreShutdown;
         public event EventHandler<EmulatorPromptEventArgs> EmulatorPrompt;
+        public event EventHandler<ServerStartEventArgs> ServerStart;
+        public event EventHandler<ServerStopEventArgs> ServerStop;
 
         public void OnAjaxRequestReceived(AjaxRequestReceivedEventArgs e)
         {
@@ -47,6 +49,20 @@ namespace Snowflake.Events
             if (this.EmulatorPrompt != null)
             {
                 this.EmulatorPrompt(this, e);
+            }
+        }
+        public void OnServerStart(ServerStartEventArgs e)
+        {
+            if (this.ServerStart != null)
+            {
+                this.ServerStart(this, e);
+            }
+        }
+        public void OnServerStop(ServerStopEventArgs e)
+        {
+            if (this.ServerStop != null)
+            {
+                this.ServerStop(this, e);
             }
         }
     }

--- a/Snowflake.Service/Service/Manager/ServerManager.cs
+++ b/Snowflake.Service/Service/Manager/ServerManager.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Snowflake.Service.HttpServer;
+namespace Snowflake.Service.Manager
+{
+    public class ServerManager : IServerManager
+    {
+        private IDictionary<string, IBaseHttpServer> servers;
+        public void RegisterServer(string serverName, IBaseHttpServer httpServer)
+        {
+            servers.Add(serverName, httpServer);
+        }
+
+        public void StartServer(string serverName)
+        {
+            servers[serverName].StartServer();
+        }
+
+        public void StopServer(string serverName)
+        {
+            servers[serverName].StopServer();
+        }
+
+        public IList<string> RegisteredServers
+        {
+            get 
+            {
+                return this.servers.Select(server => server.Key).ToList();
+            }
+        }
+    }
+}

--- a/Snowflake.Service/Service/Manager/ServerManager.cs
+++ b/Snowflake.Service/Service/Manager/ServerManager.cs
@@ -9,6 +9,10 @@ namespace Snowflake.Service.Manager
     public class ServerManager : IServerManager
     {
         private IDictionary<string, IBaseHttpServer> servers;
+        public ServerManager()
+        {
+            this.servers = new Dictionary<string, IBaseHttpServer>();
+        }
         public void RegisterServer(string serverName, IBaseHttpServer httpServer)
         {
             servers.Add(serverName, httpServer);

--- a/Snowflake.Service/Service/Manager/ServerManager.cs
+++ b/Snowflake.Service/Service/Manager/ServerManager.cs
@@ -35,5 +35,16 @@ namespace Snowflake.Service.Manager
                 return this.servers.Select(server => server.Key).ToList();
             }
         }
+        public IBaseHttpServer GetServer(string serverName)
+        {
+            return this.servers[serverName];
+        }
+        public IBaseHttpServer this[string serverName]
+        {
+            get
+            {
+                return this.GetServer(serverName);
+            }
+        }
     }
 }

--- a/Snowflake.Service/Service/Server/JsonApiWebSocketServer.cs
+++ b/Snowflake.Service/Service/Server/JsonApiWebSocketServer.cs
@@ -97,6 +97,10 @@ namespace Snowflake.Service.JSWebSocketServer
             this.serverThread.Start();
         }
 
+        public void StopServer()
+        {
+            this.serverThread.Abort();
+        }
         private void OnSocketOpen(IWebSocketConnection connection)
         {
             if (this.SocketOpen != null)

--- a/Snowflake.Service/Service/Server/JsonApiWebSocketServer.cs
+++ b/Snowflake.Service/Service/Server/JsonApiWebSocketServer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Snowflake.Ajax;
+using Snowflake.Service.HttpServer;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Threading;
@@ -84,7 +85,8 @@ namespace Snowflake.Service.JSWebSocketServer
             return await CoreService.LoadedCore.AjaxManager.CallMethodAsync(args);
         }
 
-        public void StartServer(){
+        void IBaseHttpServer.StartServer()
+        {
             this.serverThread = new Thread(
                 () =>
                     server.Start(socket =>
@@ -97,7 +99,7 @@ namespace Snowflake.Service.JSWebSocketServer
             this.serverThread.Start();
         }
 
-        public void StopServer()
+        void IBaseHttpServer.StopServer()
         {
             this.serverThread.Abort();
         }

--- a/Snowflake.Service/Snowflake.Service.csproj
+++ b/Snowflake.Service/Snowflake.Service.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Service\Manager\AjaxManager.cs" />
     <Compile Include="Service\Manager\EmulatorAssembliesManager.cs" />
     <Compile Include="Service\Manager\PluginManager.cs" />
+    <Compile Include="Service\Manager\ServerManager.cs" />
     <Compile Include="Service\ScrapeService.cs" />
     <Compile Include="Service\Server\FileMediaStoreServer.cs" />
     <Compile Include="Service\Server\JsonApiServer.cs" />

--- a/Snowflake.Tests/Fakes/FakeCoreService.cs
+++ b/Snowflake.Tests/Fakes/FakeCoreService.cs
@@ -76,5 +76,55 @@ namespace Snowflake.Tests.Fakes
         {
             get { throw new NotImplementedException(); }
         }
+
+        Service.Manager.IAjaxManager ICoreService.AjaxManager
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Service.Manager.IEmulatorAssembliesManager ICoreService.EmulatorManager
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        string ICoreService.AppDataDirectory
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Controller.IControllerPortsDatabase ICoreService.ControllerPortsDatabase
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Game.IGameDatabase ICoreService.GameDatabase
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Platform.IPlatformPreferenceDatabase ICoreService.PlatformPreferenceDatabase
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        IDictionary<string, Platform.IPlatformInfo> ICoreService.LoadedPlatforms
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        IDictionary<string, Controller.IControllerDefinition> ICoreService.LoadedControllers
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Service.Manager.IPluginManager ICoreService.PluginManager
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Service.Manager.IServerManager ICoreService.ServerManager
+        {
+            get { throw new NotImplementedException(); }
+        }
     }
 }

--- a/Snowflake.Tests/Service/HttpServer/BaseHttpServerTests.cs
+++ b/Snowflake.Tests/Service/HttpServer/BaseHttpServerTests.cs
@@ -20,7 +20,7 @@ namespace Snowflake.Service.HttpServer.Tests
         [Fact]
         public void BaseHttpServerStart_Test()
         {
-            var server = new FakeHttpServer();
+            IBaseHttpServer server = new FakeHttpServer();
             server.StartServer();
             using (WebClient client = new WebClient())
             {
@@ -30,7 +30,7 @@ namespace Snowflake.Service.HttpServer.Tests
         [Fact]
         public void BaseHttpServerStop_Test()
         {
-            var server = new FakeHttpServer();
+            IBaseHttpServer server = new FakeHttpServer();
             bool unableToDownload = false;
             server.StartServer();
             server.StopServer();


### PR DESCRIPTION
This adds the `IServerManager` interface to CoreService and no longer requires a web server to be coupled tightly to the `ICoreService` interface. This is a breaking change and any methods that call upon the servers directly will have to be modified to access the server through `ICoreService.ServerManager`. 