### PR TITLE
Controller Ajax API (#88)

### DIFF
--- a/Snowflake.API/Controller/IControllerPortsDatabase.cs
+++ b/Snowflake.API/Controller/IControllerPortsDatabase.cs
@@ -18,18 +18,18 @@ namespace Snowflake.Controller
         /// <param name="platformInfo">The platform to be added</param>
         void AddPlatform(IPlatformInfo platformInfo);
         /// <summary>
-        /// Gets the controller in a certain port of a platform (console)
+        /// Gets the device in a certain port of a platform (console)
         /// </summary>
         /// <param name="platformInfo">The platform in which the controller is 'plugged in'</param>
         /// <param name="portNumber">The port number where the controller is 'plugged in'</param>
         /// <returns></returns>
         string GetDeviceInPort(IPlatformInfo platformInfo, int portNumber);
         /// <summary>
-        /// Sets the controller to be used in a certain port of the platform (console)
+        /// Sets the device to be used in a certain port of the platform (console)
         /// </summary>
         /// <param name="platformInfo">The platform in which the controller is to be 'plugged in'</param>
         /// <param name="portNumber">The port number where the controller is to be 'plugged in'</param>
-        /// <param name="controllerId">The ControllerID of the controller to be 'plugged in'</param>
-        void SetDeviceInPort(IPlatformInfo platformInfo, int portNumber, string controllerId);
+        /// <param name="controllerId">The name of the device'</param>
+        void SetDeviceInPort(IPlatformInfo platformInfo, int portNumber, string deviceName);
     }
 }

--- a/Snowflake.API/Controller/IControllerProfile.cs
+++ b/Snowflake.API/Controller/IControllerProfile.cs
@@ -17,7 +17,7 @@ namespace Snowflake.Controller
         /// The mapping of inputs to keyboard or gamepad.
         /// <see cref="Snowflake.Controller.IControllerInput"/>
         /// </summary>
-        IReadOnlyDictionary<string, string> InputConfiguration { get; }
+        IDictionary<string, string> InputConfiguration { get; }
         /// <summary>
         /// Whether this profile is for a gamepad, keyboard, or unhandled (custom)
         /// </summary>
@@ -26,6 +26,6 @@ namespace Snowflake.Controller
         /// Generates an IDictionary that can be serialized to json or yaml
         /// </summary>
         /// <returns>An IDictionary that is to be serialized to json or yaml</returns>
-        IDictionary<string, dynamic> ToSerializable();
+        IDictionary<string, object> ToSerializable();
     }
 }

--- a/Snowflake.API/Service/ICoreService.cs
+++ b/Snowflake.API/Service/ICoreService.cs
@@ -4,6 +4,7 @@ using Snowflake.Service.Manager;
 using Snowflake.Service.HttpServer;
 using Snowflake.Service.JSWebSocketServer;
 using Snowflake.Emulator.Configuration;
+using Snowflake.Emulator.Input.InputManager;
 using Snowflake.Controller;
 using Snowflake.Game;
 using Snowflake.Platform;
@@ -54,5 +55,10 @@ namespace Snowflake.Service
         /// The webserver manager
         /// </summary>
         IServerManager ServerManager { get; }
+        /// <summary>
+        /// The input device manager
+        /// </summary>
+        IInputManager InputManager { get; }
+        
     }
 }

--- a/Snowflake.Core.Init/Form1.cs
+++ b/Snowflake.Core.Init/Form1.cs
@@ -41,6 +41,7 @@ namespace Snowflake.Service.Init
             InitializeComponent();
             Console.SetOut(new MultiTextWriter(new ControlWriter(this.textBox1, this), Console.Out));
             start();
+
  string x_ = @"
 [
     {
@@ -75,8 +76,8 @@ namespace Snowflake.Service.Init
             CoreService.InitCore();
             CoreService.InitPluginManager();
          //   var x = CoreService.LoadedCore.ControllerPortsDatabase.GetDeviceInPort(CoreService.LoadedCore.LoadedPlatforms.First().Value, 1);
-          //  var store = CoreService.LoadedCore.LoadedControllers["NES_CONTROLLER"].ProfileStore["KeyboardDevice"];
-           // var gameUuid = FileHash.GetMD5("christmascraze.smc");
+            var store = CoreService.LoadedCore.LoadedControllers["NES_CONTROLLER"].ProfileStore;
+            var gameUuid = FileHash.GetMD5("christmascraze.smc");
        /*     var homebrew = new GameInfo("NINTENDO_SNES", "SNES_TEST", new FileMediaStore(gameUuid), new Dictionary<string, string>(), gameUuid, "christmascraze.smc");
             CoreService.LoadedCore.GameDatabase.AddGame(homebrew);*/
 

--- a/Snowflake.Service/Service/CoreService.cs
+++ b/Snowflake.Service/Service/CoreService.cs
@@ -18,6 +18,7 @@ using Snowflake.Service.Manager;
 using Snowflake.Controller;
 using Snowflake.Game;
 using Snowflake.Emulator.Configuration;
+using Snowflake.Emulator.Input.InputManager;
 namespace Snowflake.Service
 {
     [Export(typeof(ICoreService))]
@@ -31,6 +32,7 @@ namespace Snowflake.Service
         public IPluginManager PluginManager { get; private set; }
         public IAjaxManager AjaxManager { get; private set; }
         public IGameDatabase GameDatabase { get; private set; }
+        public IInputManager InputManager { get { return new Snowflake.InputManager.InputManager(); } }
         public IControllerPortsDatabase ControllerPortsDatabase { get; private set; }
         public IPlatformPreferenceDatabase PlatformPreferenceDatabase { get; private set; }
         public IEmulatorAssembliesManager EmulatorManager { get; private set; }

--- a/Snowflake.Service/Snowflake.Service.csproj
+++ b/Snowflake.Service/Snowflake.Service.csproj
@@ -105,6 +105,10 @@
       <Project>{7ae8e842-e2a9-4f01-bec1-8a7a60cc16bb}</Project>
       <Name>Snowflake.Events</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Snowflake.InputManager.DirectInput\Snowflake.InputManager.DirectInput.csproj">
+      <Project>{f668fd18-74cb-4774-88a4-41614b2fb0ab}</Project>
+      <Name>Snowflake.InputManager.DirectInput</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Snowflake\Snowflake.csproj">
       <Project>{8f1d65ed-4a96-4a0a-8371-53655a60a2b3}</Project>
       <Name>Snowflake</Name>

--- a/Snowflake.StandardAjax/StandardAjax.Controller.cs
+++ b/Snowflake.StandardAjax/StandardAjax.Controller.cs
@@ -5,27 +5,55 @@ using System.Text;
 using System.Threading.Tasks;
 using Snowflake.Ajax;
 using Snowflake.Controller;
+using Snowflake.Platform;
 using Snowflake.Emulator.Input;
+using Newtonsoft.Json;
 namespace Snowflake.StandardAjax
 {
     public partial class StandardAjax
     {
         [AjaxMethod(MethodPrefix = "Controller")]
+        [AjaxMethodParameter(ParameterName = "controller", ParameterType = AjaxMethodParameterType.StringParameter)]
         public IJSResponse GetProfiles(IJSRequest request)
         {
-            return new JSResponse(request, null);
+            string controllerId = request.GetParameter("controller");
+            IControllerProfileStore profileStore = this.CoreInstance.LoadedControllers[controllerId].ProfileStore;
+            IDictionary<string, object> controllerProfiles = new Dictionary<string, object>();
+            foreach (string deviceName in profileStore.AvailableProfiles)
+            {
+                controllerProfiles.Add(deviceName, profileStore.GetControllerProfile(deviceName));
+            }
+            return new JSResponse(request, controllerProfiles);
+        }
+        [AjaxMethod(MethodPrefix = "Controller")]
+        [AjaxMethodParameter(ParameterName = "controller", ParameterType = AjaxMethodParameterType.StringParameter)]
+        [AjaxMethodParameter(ParameterName = "device", ParameterType = AjaxMethodParameterType.StringParameter)]
+
+        public IJSResponse GetProfileForDevice(IJSRequest request)
+        {
+            string controllerId = request.GetParameter("controller");
+            string deviceName = request.GetParameter("device");
+            IControllerProfile profile = this.CoreInstance.LoadedControllers[controllerId].ProfileStore[deviceName];
+            return new JSResponse(request, profile);
         }
 
         [AjaxMethod(MethodPrefix = "Controller")]
-        public IJSResponse SetInput(IJSRequest request)
-        {
-            return new JSResponse(request, null);
-        }
+        [AjaxMethodParameter(ParameterName = "inputconfig", ParameterType = AjaxMethodParameterType.ObjectParameter)]
+        [AjaxMethodParameter(ParameterName = "controller", ParameterType = AjaxMethodParameterType.StringParameter)]
+        [AjaxMethodParameter(ParameterName = "device", ParameterType = AjaxMethodParameterType.StringParameter)]
 
-        [AjaxMethod(MethodPrefix = "Controller")]
-        public IJSResponse LoadFileProfile(IJSRequest request)
+        public IJSResponse SetInputConfiguration(IJSRequest request)
         {
-            return new JSResponse(request, null);
+            string controllerId = request.GetParameter("controller");
+            string deviceName = request.GetParameter("device");
+            IDictionary<string, string> changes = JsonConvert.DeserializeObject<Dictionary<string, string>>(request.GetParameter("inputconfig"));
+            IControllerProfile profile = this.CoreInstance.LoadedControllers[controllerId].ProfileStore[deviceName];
+            foreach (KeyValuePair<string, string> change in changes) 
+            {
+                profile.InputConfiguration[change.Key] = change.Value;
+            }
+            this.CoreInstance.LoadedControllers[controllerId].ProfileStore.SetControllerProfile(deviceName, profile);
+            return new JSResponse(request, "success");
         }
 
         [AjaxMethod(MethodPrefix = "Controller")]
@@ -35,17 +63,22 @@ namespace Snowflake.StandardAjax
         }
 
         [AjaxMethod(MethodPrefix = "Controller")]
-        [AjaxMethodParameter(ParameterName = "controller", ParameterType = AjaxMethodParameterType.StringParameter)]
-        [AjaxMethodParameter(ParameterName = "slot", ParameterType = AjaxMethodParameterType.IntParameter)]
-        public IJSResponse SetInputDevice(IJSRequest request)
+        [AjaxMethodParameter(ParameterName = "platform", ParameterType = AjaxMethodParameterType.StringParameter)]
+        [AjaxMethodParameter(ParameterName = "port", ParameterType = AjaxMethodParameterType.IntParameter)]
+        [AjaxMethodParameter(ParameterName = "device", ParameterType = AjaxMethodParameterType.IntParameter)]
+        public IJSResponse SetDeviceInPort(IJSRequest request)
         {
+            IPlatformInfo platform = this.CoreInstance.LoadedPlatforms[request.GetParameter("platform")];
+            string deviceName = request.GetParameter("device");
+            int port = Int32.Parse(request.GetParameter("port"));
+            this.CoreInstance.ControllerPortsDatabase.SetDeviceInPort(platform, port, deviceName);
+
             return new JSResponse(request, null);
         }
         [AjaxMethod(MethodPrefix = "Controller")]
-        [AjaxMethodParameter(ParameterName = "controller", ParameterType = AjaxMethodParameterType.StringParameter)]
         public IJSResponse GetInputDevices(IJSRequest request)
         {
-            return new JSResponse(request, null);
+            return new JSResponse(request, this.CoreInstance.InputManager.GetGamepads());
         }
     }
 }

--- a/Snowflake.StandardAjax/StandardAjax.Controller.cs
+++ b/Snowflake.StandardAjax/StandardAjax.Controller.cs
@@ -73,7 +73,17 @@ namespace Snowflake.StandardAjax
             int port = Int32.Parse(request.GetParameter("port"));
             this.CoreInstance.ControllerPortsDatabase.SetDeviceInPort(platform, port, deviceName);
 
-            return new JSResponse(request, null);
+            return new JSResponse(request, "success");
+        }
+        [AjaxMethod(MethodPrefix = "Controller")]
+        [AjaxMethodParameter(ParameterName = "platform", ParameterType = AjaxMethodParameterType.StringParameter)]
+        [AjaxMethodParameter(ParameterName = "port", ParameterType = AjaxMethodParameterType.IntParameter)]
+        public IJSResponse GetDeviceInPort(IJSRequest request)
+        {
+            IPlatformInfo platform = this.CoreInstance.LoadedPlatforms[request.GetParameter("platform")];
+            int port = Int32.Parse(request.GetParameter("port"));
+
+            return new JSResponse(request, this.CoreInstance.ControllerPortsDatabase.GetDeviceInPort(platform, port));
         }
         [AjaxMethod(MethodPrefix = "Controller")]
         public IJSResponse GetInputDevices(IJSRequest request)

--- a/Snowflake.Tests/Fakes/FakeControllerProfile.cs
+++ b/Snowflake.Tests/Fakes/FakeControllerProfile.cs
@@ -14,7 +14,7 @@ namespace Snowflake.Tests.Fakes
             get { throw new NotImplementedException(); }
         }
 
-        public IReadOnlyDictionary<string, string> InputConfiguration
+        public IDictionary<string, string> InputConfiguration
         {
             get { throw new NotImplementedException(); }
         }

--- a/Snowflake.Tests/Fakes/FakeCoreService.cs
+++ b/Snowflake.Tests/Fakes/FakeCoreService.cs
@@ -126,5 +126,11 @@ namespace Snowflake.Tests.Fakes
         {
             get { throw new NotImplementedException(); }
         }
+
+
+        Emulator.Input.InputManager.IInputManager ICoreService.InputManager
+        {
+            get { throw new NotImplementedException(); }
+        }
     }
 }

--- a/Snowflake/Controller/ControllerProfile.cs
+++ b/Snowflake/Controller/ControllerProfile.cs
@@ -10,15 +10,14 @@ namespace Snowflake.Controller
 {
     public class ControllerProfile : IControllerProfile
     {
-        public IReadOnlyDictionary<string, string> InputConfiguration { get { return this.inputConfiguration.AsReadOnly(); } }
-        private IDictionary<string, string> inputConfiguration;
+        public IDictionary<string, string> InputConfiguration { get; private set; }
         public string ControllerID { get; private set; }
         public ControllerProfileType ProfileType { get; private set; }
         public ControllerProfile(string controllerId, ControllerProfileType profileType, IDictionary<string, string> inputConfiguration)
         {
             this.ControllerID = controllerId;
             this.ProfileType = profileType;
-            this.inputConfiguration = inputConfiguration;
+            this.InputConfiguration = inputConfiguration;
         }
 
         public static ControllerProfile FromJsonProtoTemplate(IDictionary<string, dynamic> protoTemplate){
@@ -29,11 +28,11 @@ namespace Snowflake.Controller
             return new ControllerProfile(controllerId, profileType, inputConfiguration);
         }
 
-        public IDictionary<string, dynamic> ToSerializable()
+        public IDictionary<string, object> ToSerializable()
         {
-            var serializable = new Dictionary<string, dynamic>();
+            var serializable = new Dictionary<string, object>();
             serializable["ControllerID"] = this.ControllerID;
-            serializable["InputConfiguration"] = this.inputConfiguration;
+            serializable["InputConfiguration"] = this.InputConfiguration;
             serializable["ProfileType"] = Enum.GetName(typeof(ControllerProfileType), this.ProfileType);
             return serializable;
         }


### PR DESCRIPTION
This implements the following API relating to controllers and input.

- `Controller.GetProfiles(controller)`

Gets all the input profile/configurations for the specified controller ID for all registered devices
- `Controller.GetProfileForDevice(controller, device)`

Gets the controller input profile for the given device and controller

- `Controller.SetInputConfiguration(inputconfig, controller, device) //todo extend to create input configurations`

Sets the input configuration data for a given device and controller. The API thus can not modify the controller profiles besides the input configuration. A job todo is to extend this API such that it can allow creation of input profiles from scratch. Input configuration is passed as a JSON object with the controller button ID as the key, and the new input key as the value, for example

```json
{
    "BTN_A": "KEY_H",
    "BTN_B": "KEY_J"
}
```

- `Controller.GetControllers()`

Gets the list of loaded controller definitions

- `Controller.GetDeviceInPort(platform, port)`

Gets the name of the specified input device in a virtual port of a platform

- `Controller.SetDeviceInPort(platform, port, device)`

Sets the input device in a virtual port of a platform

- `Controller.GetInputDevices()`

Get the input devices from the operating system using the loaded InputManager 