### PR TITLE
BREAKING MediaStore, Info, Platform: Decouple mediastore from Info and remove it from a serialized property of GameInfo to conform with new Stone specification

### DIFF
--- a/Platforms/NINTENDO_NES.platform
+++ b/Platforms/NINTENDO_NES.platform
@@ -1,7 +1,6 @@
 {
     "PlatformID": "NINTENDO_NES",
     "Name": "Nintendo Entertainment System",
-    "MediaStoreKey": "platform.NINTENDO_NES",
     "FileExtensions": [
         ".nes"
     ],

--- a/Platforms/NINTENDO_SNES.platform
+++ b/Platforms/NINTENDO_SNES.platform
@@ -1,7 +1,6 @@
 {
     "PlatformID": "NINTENDO_SNES",
     "Name": "Super Nintendo Entertainment System",
-    "MediaStoreKey": "platform.NINTENDO_SNES",
     "FileExtensions": [
         ".sfc",
 		".smc"

--- a/Snowflake.API/Game/IGameInfo.cs
+++ b/Snowflake.API/Game/IGameInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Snowflake.Information;
+using Snowflake.Information.MediaStore;
 namespace Snowflake.Game
 {
     /// <summary>
@@ -19,5 +20,11 @@ namespace Snowflake.Game
         /// The unique ID of the game
         /// </summary>
         string UUID { get; }
+        //Gets the mediastore
+        IMediaStore MediaStore { get; }
+        /// <summary>
+        /// The mediastore key
+        /// </summary>
+        string MediaStoreKey { get; }
     }
 }

--- a/Snowflake.API/Game/IGameInfo.cs
+++ b/Snowflake.API/Game/IGameInfo.cs
@@ -20,11 +20,10 @@ namespace Snowflake.Game
         /// The unique ID of the game
         /// </summary>
         string UUID { get; }
-        //Gets the mediastore
+        ///<summary>
+        ///If the mediastore exists, returns the mediastore.
+        ///The key to access the mediastore is accessed under snowflake_mediastore in the game metadata
+        ///</summary>
         IMediaStore MediaStore { get; }
-        /// <summary>
-        /// The mediastore key
-        /// </summary>
-        string MediaStoreKey { get; }
     }
 }

--- a/Snowflake.API/Information/IInfo.cs
+++ b/Snowflake.API/Information/IInfo.cs
@@ -22,10 +22,5 @@ namespace Snowflake.Information
         /// Any metadata that is attached to this object, such as descriptions
         /// </summary>
         IDictionary<string, string> Metadata { get; set; }
-        /// <summary>
-        /// The mediastore that is attached to this object.
-        /// </summary>
-        IMediaStore MediaStore { get;  }
-
     }
 }

--- a/Snowflake.Core.Init/Form1.cs
+++ b/Snowflake.Core.Init/Form1.cs
@@ -77,7 +77,6 @@ namespace Snowflake.Service.Init
             CoreService.InitPluginManager();
          //   var x = CoreService.LoadedCore.ControllerPortsDatabase.GetDeviceInPort(CoreService.LoadedCore.LoadedPlatforms.First().Value, 1);
             var store = CoreService.LoadedCore.LoadedControllers["NES_CONTROLLER"].ProfileStore;
-            var gameUuid = FileHash.GetMD5("christmascraze.smc");
        /*     var homebrew = new GameInfo("NINTENDO_SNES", "SNES_TEST", new FileMediaStore(gameUuid), new Dictionary<string, string>(), gameUuid, "christmascraze.smc");
             CoreService.LoadedCore.GameDatabase.AddGame(homebrew);*/
 

--- a/Snowflake.Service/Service/ScrapeService.cs
+++ b/Snowflake.Service/Service/ScrapeService.cs
@@ -57,7 +57,7 @@ namespace Snowflake.Service
                 gameUuid,
                 fileName
             );
-            resultdetails.Item2.ToMediaStore(gameResult.MediaStoreKey);
+            resultdetails.Item2.ToMediaStore(gameResult.Metadata["snowflake_mediastorekey"]);
             return gameResult;
         }
 

--- a/Snowflake.Service/Service/ScrapeService.cs
+++ b/Snowflake.Service/Service/ScrapeService.cs
@@ -49,14 +49,16 @@ namespace Snowflake.Service
             var resultdetails = this.ScraperPlugin.GetGameDetails(id);
             var gameinfo = resultdetails.Item1;
             var gameUuid = FileHash.GetMD5(fileName);
-            return new GameInfo(
+            gameinfo.Add("snowflake_mediastorekey", ScrapeService.ValidateFilename(gameinfo[GameInfoFields.game_title]).Replace(' ', '_') + gameUuid);
+            var gameResult = new GameInfo(
                 this.ScrapePlatform.PlatformID,
                 gameinfo[GameInfoFields.game_title],
-                resultdetails.Item2.ToMediaStore("game." + ScrapeService.ValidateFilename(gameinfo[GameInfoFields.game_title]).Replace(' ', '_') + gameUuid),
                 gameinfo,
                 gameUuid,
                 fileName
             );
+            resultdetails.Item2.ToMediaStore(gameResult.MediaStoreKey);
+            return gameResult;
         }
 
         public IGameInfo GetGameInfo(string fileName)

--- a/Snowflake.Tests/Fakes/FakeGameInfo.cs
+++ b/Snowflake.Tests/Fakes/FakeGameInfo.cs
@@ -49,5 +49,11 @@ namespace Snowflake.Tests.Fakes
         {
             get { throw new NotImplementedException(); }
         }
+
+
+        public string MediaStoreKey
+        {
+            get { throw new NotImplementedException(); }
+        }
     }
 }

--- a/Snowflake.Tests/Game/GameInfoTests.cs
+++ b/Snowflake.Tests/Game/GameInfoTests.cs
@@ -13,7 +13,7 @@ namespace Snowflake.Game.Tests
         [Fact]
         public void GameInfoCreation_Test()
         {
-            Assert.NotNull(new GameInfo("TEST", "TEST", new FakeMediaStore(), new Dictionary<string, string>(), "TEST", "TEST.TEST", "TEST"));
+            Assert.NotNull(new GameInfo("TEST", "TEST", new Dictionary<string, string>(){{"snowflake_mediastore", "TEST"}}, "TEST", "TEST.TEST", "TEST"));
         }
 
     }

--- a/Snowflake/Game/GameDatabase.cs
+++ b/Snowflake/Game/GameDatabase.cs
@@ -119,11 +119,10 @@ namespace Snowflake.Game
             var uuid = row.Field<string>("uuid");
             var fileName = row.Field<string>("filename");
             var name = row.Field<string>("name");
-            var mediaStore = new FileMediaStore(row.Field<string>("mediastorekey"));
             var metadata = JsonConvert.DeserializeObject<IDictionary<string, string>>(row.Field<string>("metadata"));
             var crc32 = row.Field<string>("crc32");
 
-            return new GameInfo(platformId, name, mediaStore, metadata, uuid, fileName, crc32);
+            return new GameInfo(platformId, name, metadata, uuid, fileName, crc32);
         }
 
     }

--- a/Snowflake/Game/GameDatabase.cs
+++ b/Snowflake/Game/GameDatabase.cs
@@ -30,7 +30,6 @@ namespace Snowflake.Game
                                                                 uuid TEXT PRIMARY KEY,
                                                                 filename TEXT,
                                                                 name TEXT,
-                                                                mediastorekey TEXT,
                                                                 metadata TEXT,
                                                                 crc32 TEXT
                                                                 )", this.DBConnection);
@@ -46,7 +45,6 @@ namespace Snowflake.Game
                                           @uuid,
                                           @filename,
                                           @name,
-                                          @mediastorekey,
                                           @metadata,
                                           @crc32)", this.DBConnection))
             {
@@ -54,7 +52,6 @@ namespace Snowflake.Game
                 sqlCommand.Parameters.AddWithValue("@uuid", game.UUID);
                 sqlCommand.Parameters.AddWithValue("@filename", game.FileName);
                 sqlCommand.Parameters.AddWithValue("@name", game.Name);
-                sqlCommand.Parameters.AddWithValue("@mediastorekey", game.MediaStore.MediaStoreKey);
                 sqlCommand.Parameters.AddWithValue("@metadata", JsonConvert.SerializeObject(game.Metadata));
                 sqlCommand.Parameters.AddWithValue("@crc32", game.CRC32);
                 sqlCommand.ExecuteNonQuery();

--- a/Snowflake/Game/GameInfo.cs
+++ b/Snowflake/Game/GameInfo.cs
@@ -16,7 +16,7 @@ namespace Snowflake.Game
         public string CRC32 { get; private set; }
         public string MediaStoreKey { get; private set; }
         public IMediaStore MediaStore { get { return new FileMediaStore(this.MediaStoreKey); } }
-        public GameInfo(string platformId, string name, IMediaStore mediaStore, IDictionary<string, string> metadata, string uuid, string fileName, string crc32)
+        public GameInfo(string platformId, string name, IDictionary<string, string> metadata, string uuid, string fileName, string crc32)
             : base(platformId, name, metadata)
         {
             this.MediaStoreKey = this.Metadata["kori_mediastorekey"];

--- a/Snowflake/Game/GameInfo.cs
+++ b/Snowflake/Game/GameInfo.cs
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 using Snowflake.Information.MediaStore;
 using Snowflake.Information;
 using Snowflake.Utility;
-
+using System.IO;
+using Newtonsoft.Json;
 namespace Snowflake.Game
 {
     public class GameInfo : Info, IGameInfo
@@ -14,30 +15,53 @@ namespace Snowflake.Game
         public string UUID { get; private set; }
         public string FileName { get; private set; }
         public string CRC32 { get; private set; }
-        public string MediaStoreKey { get; private set; }
-        public IMediaStore MediaStore { get { return new FileMediaStore(this.MediaStoreKey); } }
+        [JsonIgnore]
+        public IMediaStore MediaStore { get { return new FileMediaStore(this.Metadata["snowflake_mediastorekey"]); } }
         public GameInfo(string platformId, string name, IDictionary<string, string> metadata, string uuid, string fileName, string crc32)
             : base(platformId, name, metadata)
         {
-            this.MediaStoreKey = this.Metadata["kori_mediastorekey"];
+            if(!this.Metadata.ContainsKey("snowflake_mediastorekey")){
+                this.Metadata.Add("snowflake_mediastorekey", GameInfo.ValidateFilename(metadata["game_title"]).Replace(' ', '_') + uuid);
+            }
             this.UUID = uuid;
             this.FileName = fileName;
             this.CRC32 = crc32;
         }
-        public GameInfo(string platformId, string name, IMediaStore mediaStore, IDictionary<string, string> metadata, string uuid, string fileName)
-            : this(platformId, name, mediaStore, metadata, uuid, fileName, FileHash.GetCRC32(fileName)) { }
+        public GameInfo(string platformId, string name, IDictionary<string, string> metadata, string uuid, string fileName)
+            : this(platformId, name, metadata, uuid, fileName, FileHash.GetCRC32(fileName)) { }
 
         public static IGameInfo FromJson(dynamic json)
         {
             var metadata = json.Metadata.ToObject<IDictionary<string, string>>();
-            string mediaStoreKey = json.MediaStore.MediaStoreKey;
-            var mediastore = new FileMediaStore(mediaStoreKey);
             string platformId = json.PlatformID;
             string name = json.Name;
             string uuid = json.UUID;
             string fileName = json.FileName;
             string crc32 = json.CRC32;
-            return new GameInfo(platformId, name, mediastore, metadata, uuid, fileName, crc32);
+            return new GameInfo(platformId, name, metadata, uuid, fileName, crc32);
+        }
+        private static string ValidateFilename(string text, char? replacement = '_')
+        {
+            //from http://stackoverflow.com/a/25223884/1822679
+            StringBuilder sb = new StringBuilder(text.Length);
+            var invalids = Path.GetInvalidFileNameChars();
+            bool changed = false;
+            for (int i = 0; i < text.Length; i++)
+            {
+                char c = text[i];
+                if (invalids.Contains(c))
+                {
+                    changed = true;
+                    var repl = replacement ?? '\0';
+                    if (repl != '\0')
+                        sb.Append(repl);
+                }
+                else
+                    sb.Append(c);
+            }
+            if (sb.Length == 0)
+                return "_";
+            return changed ? sb.ToString() : text;
         }
     }
 }

--- a/Snowflake/Game/GameInfo.cs
+++ b/Snowflake/Game/GameInfo.cs
@@ -14,9 +14,12 @@ namespace Snowflake.Game
         public string UUID { get; private set; }
         public string FileName { get; private set; }
         public string CRC32 { get; private set; }
+        public string MediaStoreKey { get; private set; }
+        public IMediaStore MediaStore { get { return new FileMediaStore(this.MediaStoreKey); } }
         public GameInfo(string platformId, string name, IMediaStore mediaStore, IDictionary<string, string> metadata, string uuid, string fileName, string crc32)
-            : base(platformId, name, mediaStore, metadata)
+            : base(platformId, name, metadata)
         {
+            this.MediaStoreKey = this.Metadata["kori_mediastorekey"];
             this.UUID = uuid;
             this.FileName = fileName;
             this.CRC32 = crc32;

--- a/Snowflake/Information/Info.cs
+++ b/Snowflake/Information/Info.cs
@@ -7,14 +7,12 @@ namespace Snowflake.Information
     {
         public string PlatformID { get; private set; }
         public string Name { get; private set; }
-        public IMediaStore MediaStore { get; private set; }
         public IDictionary<string, string> Metadata { get; set; }
 
-        public Info(string platformId, string name, IMediaStore mediastore, IDictionary<string,string> metadata)
+        public Info(string platformId, string name, IDictionary<string,string> metadata)
         {
             this.PlatformID = platformId;
             this.Name = name;
-            this.MediaStore = mediastore;
             this.Metadata = metadata;
         }
 

--- a/Snowflake/Platform/PlatformInfo.cs
+++ b/Snowflake/Platform/PlatformInfo.cs
@@ -14,7 +14,7 @@ namespace Snowflake.Platform
 {
     public class PlatformInfo : Info, IPlatformInfo
     {
-        public PlatformInfo(string platformId, string name, IMediaStore mediastore, IDictionary<string, string> metadata, IList<string> fileExtensions, IPlatformDefaults platformDefaults, IList<string> controllers, int maximumInputs, IPlatformControllerPorts controllerPorts): base(platformId, name, mediastore, metadata)
+        public PlatformInfo(string platformId, string name, IDictionary<string, string> metadata, IList<string> fileExtensions, IPlatformDefaults platformDefaults, IList<string> controllers, int maximumInputs, IPlatformControllerPorts controllerPorts): base(platformId, name, metadata)
         {
             this.FileExtensions = fileExtensions;
             this.Defaults = platformDefaults;
@@ -35,7 +35,6 @@ namespace Snowflake.Platform
             return new PlatformInfo(
                     jsonDictionary["PlatformID"],
                     jsonDictionary["Name"],
-                    new FileMediaStore(jsonDictionary["MediaStoreKey"]),
                     jsonDictionary["Metadata"].ToObject<Dictionary<string, string>>(),
                     jsonDictionary["FileExtensions"].ToObject<List<string>>(),
                     platformDefaults,


### PR DESCRIPTION
This brings Snowflake back into compliance with https://github.com/SnowflakePowered/stone/commit/3045b582b226dc22b6483776a7f06c2f6d0a4875. The mediastore key is no longer stored as a separate column and instead is treated as optional metadata. IInfo no longer implements a required MediaStore; as such, Snowflake no longer requires nor supports Platforms having their own mediastore. Media such as logos and models for a platform are to be the responsibility of the theme or implementation detail. MediaStores are now only for games. IGameInfo no longer serializes with a mediastore or a mediastore key as a top level property, the mediastore key is now accessible as a piece of metadata under the key `snowflake_mediastorekey`. 

Improvements to the FileMediaStoreServer must be made to make easy API usage under this change