### PR TITLE
BREAKING Improve PlatformDefaults and PlatformDefaultsDatabase (#103)

### DIFF
--- a/Platforms/NINTENDO_NES.platform
+++ b/Platforms/NINTENDO_NES.platform
@@ -4,11 +4,6 @@
     "FileExtensions": [
         ".nes"
     ],
-    "Defaults": {
-        "Scraper": "Scraper.TheGamesDB",
-        "Identifier": "Identifier.ClrMameProDat",
-        "Emulator": "Emulator.RetroArch"
-    },
     "Metadata": {
         "platform_shortname": "NES",
         "platform_company": "Nintendo",

--- a/Platforms/NINTENDO_SNES.platform
+++ b/Platforms/NINTENDO_SNES.platform
@@ -5,11 +5,6 @@
         ".sfc",
 		".smc"
     ],
-    "Defaults": {
-		"Scraper": "Scraper.TheGamesDB",
-		"Identifier": "Identifier.ClrMameProDat",
-		"Emulator": "Emulator.RetroArch" 
-	},
     "Metadata": {
         "platform_shortname": "SNES",
         "platform_company": "Nintendo",

--- a/Snowflake.API/Platform/IPlatformDefaults.cs
+++ b/Snowflake.API/Platform/IPlatformDefaults.cs
@@ -12,10 +12,6 @@ namespace Snowflake.Platform
         /// </summary>
         string Emulator { get; set; }
         /// <summary>
-        /// The default identifier plugin
-        /// </summary>
-        string Identifier { get; set; }
-        /// <summary>
         /// The default scraper plugin
         /// </summary>
         string Scraper { get; set; }

--- a/Snowflake.API/Platform/IPlatformInfo.cs
+++ b/Snowflake.API/Platform/IPlatformInfo.cs
@@ -11,10 +11,6 @@ namespace Snowflake.Platform
     public interface IPlatformInfo : IInfo
     {
         /// <summary>
-        /// The defaults used to populate IPlatformPreferenceDatabase entry
-        /// </summary>
-        IPlatformDefaults Defaults { get; set; }
-        /// <summary>
         /// The file extensions ROMs of this platform are known to have.
         /// </summary>
         IList<string> FileExtensions { get; }

--- a/Snowflake.API/Platform/IPlatformPreferenceDatabase.cs
+++ b/Snowflake.API/Platform/IPlatformPreferenceDatabase.cs
@@ -35,11 +35,5 @@ namespace Snowflake.Platform
         /// <param name="platformInfo">The platform</param>
         /// <param name="value">The preferred scraper for a platform</param>
         void SetScraper(IPlatformInfo platformInfo, string value);
-        /// <summary>
-        /// Sets the preferred identifier for a platform
-        /// </summary>
-        /// <param name="platformInfo">The platform</param>
-        /// <param name="value">The preferred identifier for a platform</param>
-        void SetIdentifier(IPlatformInfo platformInfo, string value);
     }
 }

--- a/Snowflake.Service/Extensions/PlatformExts.cs
+++ b/Snowflake.Service/Extensions/PlatformExts.cs
@@ -21,5 +21,17 @@ namespace Snowflake.Extensions
         {
             return new ScrapeService(platform);
         }
+        /// <summary>
+        /// This method is used as part of a core function, 
+        /// and does not serve the pure data role of the PlatformInfo class.
+        /// Extension methods are put in when they are unrelated to the class and is not used as part of the class.
+        /// </summary>
+        /// <param name="platform"></param>
+        /// <param name="scraperName">The name of the scraper</param>
+        /// <returns></returns>s
+        public static ScrapeService GetScrapeEngine(this IPlatformInfo platform, string scraperName)
+        {
+            return new ScrapeService(platform, scraperName);
+        }
     }
 }

--- a/Snowflake.Service/Service/CoreService.cs
+++ b/Snowflake.Service/Service/CoreService.cs
@@ -63,6 +63,11 @@ namespace Snowflake.Service
             CoreService.LoadedCore.EmulatorManager.LoadEmulatorAssemblies();
             CoreService.LoadedCore.PluginManager.LoadAll();
             CoreService.LoadedCore.AjaxManager.LoadAll();
+            foreach (PlatformInfo platform in CoreService.LoadedCore.LoadedPlatforms.Values)
+            {
+                CoreService.LoadedCore.ControllerPortsDatabase.AddPlatform(platform);
+                CoreService.LoadedCore.PlatformPreferenceDatabase.AddPlatform(platform);
+            }
         }
 
         public CoreService() : this(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Snowflake")) { }
@@ -76,16 +81,11 @@ namespace Snowflake.Service
             this.LoadedControllers = this.LoadControllers(Path.Combine(this.AppDataDirectory, "controllers"));
             this.ServerManager = new ServerManager();
             this.GameDatabase = new GameDatabase(Path.Combine(this.AppDataDirectory, "games.db"));
-            this.PlatformPreferenceDatabase = new PlatformPreferencesDatabase(Path.Combine(this.AppDataDirectory, "platformprefs.db"));
             this.ControllerPortsDatabase = new ControllerPortsDatabase(Path.Combine(this.AppDataDirectory, "ports.db"));
-            foreach (PlatformInfo platform in this.LoadedPlatforms.Values)
-            {
-                this.ControllerPortsDatabase.AddPlatform(platform);
-                this.PlatformPreferenceDatabase.AddPlatform(platform);
-            }
             this.PluginManager = new PluginManager(this.AppDataDirectory);
             this.AjaxManager = new AjaxManager(this.AppDataDirectory);
             this.EmulatorManager = new EmulatorAssembliesManager(Path.Combine(this.AppDataDirectory, "emulators"));
+            this.PlatformPreferenceDatabase = new PlatformPreferencesDatabase(Path.Combine(this.AppDataDirectory, "platformprefs.db"), this.PluginManager);
 
             this.ServerManager.RegisterServer("ThemeServer", new ThemeServer(Path.Combine(this.AppDataDirectory, "theme")));
             this.ServerManager.RegisterServer("AjaxApiServer", new ApiServer());

--- a/Snowflake.Service/Service/ScrapeService.cs
+++ b/Snowflake.Service/Service/ScrapeService.cs
@@ -18,11 +18,13 @@ namespace Snowflake.Service
     {
         private IPlatformInfo ScrapePlatform { get; set; }
         private IScraper ScraperPlugin { get; set; }
-        public ScrapeService(IPlatformInfo scrapePlatform)
+        public ScrapeService(IPlatformInfo scrapePlatform, string scraperName)
         {
             this.ScrapePlatform = scrapePlatform;
-            var scraperName = CoreService.LoadedCore.PlatformPreferenceDatabase.GetPreferences(this.ScrapePlatform).Scraper;
             this.ScraperPlugin = CoreService.LoadedCore.PluginManager.LoadedScrapers[scraperName];
+        }
+        public ScrapeService(IPlatformInfo scrapePlatform) : this(scrapePlatform, CoreService.LoadedCore.PlatformPreferenceDatabase.GetPreferences(this.ScrapePlatform).Scraper)
+        {
         }
 
         public IList<IGameScrapeResult> GetGameResults(string fileName)

--- a/Snowflake.Service/Service/ScrapeService.cs
+++ b/Snowflake.Service/Service/ScrapeService.cs
@@ -23,7 +23,7 @@ namespace Snowflake.Service
             this.ScrapePlatform = scrapePlatform;
             this.ScraperPlugin = CoreService.LoadedCore.PluginManager.LoadedScrapers[scraperName];
         }
-        public ScrapeService(IPlatformInfo scrapePlatform) : this(scrapePlatform, CoreService.LoadedCore.PlatformPreferenceDatabase.GetPreferences(this.ScrapePlatform).Scraper)
+        public ScrapeService(IPlatformInfo scrapePlatform) : this (scrapePlatform, CoreService.LoadedCore.PlatformPreferenceDatabase.GetPreferences(scrapePlatform).Scraper)
         {
         }
 

--- a/Snowflake.StandardAjax/StandardAjax.Game.cs
+++ b/Snowflake.StandardAjax/StandardAjax.Game.cs
@@ -25,6 +25,20 @@ namespace Snowflake.StandardAjax
             string platform = request.GetParameter("platform");
             return new JSResponse(request, this.CoreInstance.LoadedPlatforms[platform].GetScrapeEngine().GetGameResults(filename));
         }
+
+        [AjaxMethod(MethodPrefix = "Game")]
+        [AjaxMethodParameter(ParameterName = "filename", ParameterType = AjaxMethodParameterType.StringParameter)]
+        [AjaxMethodParameter(ParameterName = "platform", ParameterType = AjaxMethodParameterType.StringParameter)]
+        [AjaxMethodParameter(ParameterName = "scraper", ParameterType = AjaxMethodParameterType.StringParameter)]
+        public IJSResponse GetGameResultsUsingScraper(IJSRequest request)
+        {
+            string filename = request.GetParameter("filename");
+            string platform = request.GetParameter("platform");
+            string scraperId = request.GetParameter("scraper");
+
+            return new JSResponse(request, this.CoreInstance.LoadedPlatforms[platform].GetScrapeEngine(scraperId).GetGameResults(filename));
+        }
+
         [AjaxMethod(MethodPrefix = "Game")]
         [AjaxMethodParameter(ParameterName = "resultid", ParameterType = AjaxMethodParameterType.StringParameter)]
         [AjaxMethodParameter(ParameterName = "filename", ParameterType = AjaxMethodParameterType.StringParameter)]

--- a/Snowflake/Platform/PlatformDefaults.cs
+++ b/Snowflake/Platform/PlatformDefaults.cs
@@ -9,13 +9,11 @@ namespace Snowflake.Platform
     public class PlatformDefaults : IPlatformDefaults
     {
         public string Scraper { get; set; }
-        public string Identifier { get; set; }
         public string Emulator { get; set; }
 
-        public PlatformDefaults(string scraper, string identifier, string emulator)
+        public PlatformDefaults(string scraper, string emulator)
         {
             this.Scraper = scraper;
-            this.Identifier = identifier;
             this.Emulator = emulator;
         }
     }

--- a/Snowflake/Platform/PlatformInfo.cs
+++ b/Snowflake/Platform/PlatformInfo.cs
@@ -14,30 +14,25 @@ namespace Snowflake.Platform
 {
     public class PlatformInfo : Info, IPlatformInfo
     {
-        public PlatformInfo(string platformId, string name, IDictionary<string, string> metadata, IList<string> fileExtensions, IPlatformDefaults platformDefaults, IList<string> controllers, int maximumInputs, IPlatformControllerPorts controllerPorts): base(platformId, name, metadata)
+        public PlatformInfo(string platformId, string name, IDictionary<string, string> metadata, IList<string> fileExtensions, IList<string> controllers, int maximumInputs, IPlatformControllerPorts controllerPorts): base(platformId, name, metadata)
         {
             this.FileExtensions = fileExtensions;
-            this.Defaults = platformDefaults;
             this.Controllers = controllers;
             this.ControllerPorts = controllerPorts;
             this.MaximumInputs = maximumInputs;
         }
        
         public IList<string> FileExtensions { get; private set; }
-        public IPlatformDefaults Defaults { get; set; }
         public IList<string> Controllers { get; private set; }
         public IPlatformControllerPorts ControllerPorts { get; private set; }
         public int MaximumInputs { get; private set; }
         public static IPlatformInfo FromJsonProtoTemplate(IDictionary<string, dynamic> jsonDictionary)
         {
-            IPlatformDefaults platformDefaults = jsonDictionary["Defaults"].ToObject<PlatformDefaults>();
-
             return new PlatformInfo(
                     jsonDictionary["PlatformID"],
                     jsonDictionary["Name"],
                     jsonDictionary["Metadata"].ToObject<Dictionary<string, string>>(),
                     jsonDictionary["FileExtensions"].ToObject<List<string>>(),
-                    platformDefaults,
                     jsonDictionary["Controllers"].ToObject<List<string>>(),
                     (int)jsonDictionary["MaximumInputs"] ,
                     PlatformControllerPorts.ParseControllerPorts(jsonDictionary["ControllerPorts"].ToObject<Dictionary<string, string>>())

--- a/Snowflake/Platform/PlatformPreferencesDatabase.cs
+++ b/Snowflake/Platform/PlatformPreferencesDatabase.cs
@@ -22,7 +22,6 @@ namespace Snowflake.Platform
                                                                 platform_id TEXT PRIMARY KEY,
                                                                 emulator TEXT,
                                                                 scraper TEXT,
-                                                                identifier TEXT
                                                                 )", this.DBConnection);
             sqlCommand.ExecuteNonQuery();
             this.DBConnection.Close();
@@ -33,13 +32,11 @@ namespace Snowflake.Platform
             using (var sqlCommand = new SQLiteCommand(@"INSERT OR IGNORE INTO platformprefs VALUES(
                                           @platform_id,
                                           @emulator,
-                                          @scraper,
-                                          @identifier)", this.DBConnection))
+                                          @scraper)", this.DBConnection))
             {
                 sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformID);
                 sqlCommand.Parameters.AddWithValue("@emulator", platformInfo.Defaults.Emulator);
                 sqlCommand.Parameters.AddWithValue("@scraper", platformInfo.Defaults.Scraper);
-                sqlCommand.Parameters.AddWithValue("@identifier", platformInfo.Defaults.Identifier);
                 sqlCommand.ExecuteNonQuery();
             }
             this.DBConnection.Close();
@@ -75,11 +72,6 @@ namespace Snowflake.Platform
         {
             this.SetColumn(platformInfo, "scraper", value);
         }
-        public void SetIdentifier(IPlatformInfo platformInfo, string value)
-        {
-            this.SetColumn(platformInfo, "identifier", value);
-        }
-
         private void SetColumn(IPlatformInfo platformInfo, string column, string value)
         {
             this.DBConnection.Open();

--- a/Snowflake/Snowflake.csproj
+++ b/Snowflake/Snowflake.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <NuGetPackageImportStamp>8a9fed7c</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Snowflake/app.config
+++ b/Snowflake/app.config
@@ -1,26 +1,26 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
   </configSections>
   <system.data>
     <DbProviderFactories>
-      <remove invariant="System.Data.SQLite" />
-      <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".Net Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
-      <remove invariant="System.Data.SQLite.EF6" />
-      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".Net Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
+      <remove invariant="System.Data.SQLite"/>
+      <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".Net Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite"/>
+      <remove invariant="System.Data.SQLite.EF6"/>
+      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".Net Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6"/>
     </DbProviderFactories>
   </system.data>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
-        <parameter value="v11.0" />
+        <parameter value="v11.0"/>
       </parameters>
     </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
-      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6"/>
     </providers>
   </entityFramework>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>


### PR DESCRIPTION
This PR cleans up usage of the PlatformDefaults and PlatformPreferencesDatabase. 

PlatformDefaults are now only used when returning an object form the PlatformPreferencesDatabase. The Platform definition no longer stores it's own set of defaults, instead they are inferred from currently available plugins and stored by snowflake the first time a platform is installed. 

This breaks the IPlatformInfo interface and any classes that utilized the PlatformDefaults property will no longer function. 