### PR TITLE
Switch to index-based select values (#109)

### DIFF
--- a/Snowflake.Service/Service/CoreService.cs
+++ b/Snowflake.Service/Service/CoreService.cs
@@ -96,7 +96,7 @@ namespace Snowflake.Service
         private IDictionary<string, IPlatformInfo> LoadPlatforms(string platformDirectory)
         {
             var loadedPlatforms = new Dictionary<string, IPlatformInfo>();
-
+            if (!Directory.Exists(platformDirectory)) Directory.CreateDirectory(platformDirectory);
             foreach (string fileName in Directory.GetFiles(platformDirectory).Where(fileName => Path.GetExtension(fileName) == ".platform"))
             {
                 try
@@ -117,7 +117,7 @@ namespace Snowflake.Service
         private IDictionary<string, IControllerDefinition> LoadControllers(string controllerDirectory)
         {
             var loadedControllers = new Dictionary<string, IControllerDefinition>();
-
+            if (!Directory.Exists(controllerDirectory)) Directory.CreateDirectory(controllerDirectory);
             foreach (string fileName in Directory.GetFiles(controllerDirectory).Where(fileName => Path.GetExtension(fileName) == ".controller"))
             {
                 try

--- a/Snowflake.Service/Service/Manager/AjaxManager.cs
+++ b/Snowflake.Service/Service/Manager/AjaxManager.cs
@@ -69,6 +69,7 @@ namespace Snowflake.Service.Manager
 
         private void ComposeImports()
         {
+            if (!Directory.Exists(Path.Combine(this.LoadablesLocation, "ajax"))) Directory.CreateDirectory(Path.Combine(this.LoadablesLocation, "ajax"));
             var catalog = new DirectoryCatalog(Path.Combine(this.LoadablesLocation, "ajax"));
             var container = new CompositionContainer(catalog);
             container.ComposeExportedValue("coreInstance", CoreService.LoadedCore);

--- a/Snowflake.Service/Service/Manager/EmulatorAssembliesManager.cs
+++ b/Snowflake.Service/Service/Manager/EmulatorAssembliesManager.cs
@@ -22,7 +22,8 @@ namespace Snowflake.Service.Manager
         }
 
         public void LoadEmulatorAssemblies()
-        { 
+        {
+            if (!Directory.Exists(this.AssembliesLocation)) Directory.CreateDirectory(this.AssembliesLocation);
             foreach (string fileName in Directory.GetFiles(this.AssembliesLocation))
             {
                 if (!(Path.GetExtension(fileName) == ".yml")) continue;

--- a/Snowflake.Service/Service/Manager/PluginManager.cs
+++ b/Snowflake.Service/Service/Manager/PluginManager.cs
@@ -59,6 +59,8 @@ namespace Snowflake.Service.Manager
         }
         private void ComposeImports()
         {
+            if (!Directory.Exists(Path.Combine(this.LoadablesLocation, "plugins"))) Directory.CreateDirectory(Path.Combine(this.LoadablesLocation, "plugins"));
+
             var catalog = new DirectoryCatalog(Path.Combine(this.LoadablesLocation, "plugins"));
             var container = new CompositionContainer(catalog);
             container.ComposeExportedValue("coreInstance", CoreService.LoadedCore);

--- a/Snowflake.StandardAjax/StandardAjax.Game.cs
+++ b/Snowflake.StandardAjax/StandardAjax.Game.cs
@@ -158,14 +158,7 @@ namespace Snowflake.StandardAjax
                     castedValue = Int32.Parse(value);
                     break;
                 case ConfigurationFlagTypes.SELECT_FLAG:
-                    if (!flag.SelectValues.Select(values => values.Value).Contains(value))
-                    {
-                        throw new ArgumentException("Value not expected");
-                    }
-                    else
-                    {
-                        castedValue = value;
-                    }
+                    castedValue = Int32.Parse(value);
                     break;
             }
             bridge.ConfigurationFlagStore.SetValue(game, flag.Key, castedValue, flag.Type);
@@ -193,14 +186,7 @@ namespace Snowflake.StandardAjax
                     castedValue = Int32.Parse(value);
                     break;
                 case ConfigurationFlagTypes.SELECT_FLAG:
-                    if (!flag.SelectValues.Select(values => values.Value).Contains(value))
-                    {
-                        throw new ArgumentException("Value not expected");
-                    }
-                    else
-                    {
-                        castedValue = value;
-                    }
+                    castedValue = Int32.Parse(value);
                     break;
             }
             bridge.ConfigurationFlagStore.SetDefaultValue(flag.Key, castedValue, flag.Type);


### PR DESCRIPTION
This PR fixes issue #109 and returns select flags by their index rather than value. Emulator bridges must use this index to grab the correct flag. This will break the select value if the bridge plugin maintainer prepends new select values instead of appending but this is the responsibility of the plugin maintainer to ensure backwards compatibility.