### PR TITLE
Prevent NREs due to invalid access to stores and database

### DIFF
--- a/Snowflake.API/Controller/ControllerProfileType.cs
+++ b/Snowflake.API/Controller/ControllerProfileType.cs
@@ -23,6 +23,10 @@ namespace Snowflake.Controller
         /// A custom (unknown) type of profile. 
         /// <remarks>A controller with type <b>CUSTOM_PROFILE</b> is unhandled, the <see cref="Snowflake.Emulator.IEmulatorBridge"/> must handle this case manually</remarks>
         /// </summary>
-        CUSTOM_PROFILE
+        CUSTOM_PROFILE,
+        /// <summary>
+        /// A stubbed, empty profile
+        /// </summary>
+        NULL_PROFILE
     }
 }

--- a/Snowflake.API/Utility/BaseDatabase.cs
+++ b/Snowflake.API/Utility/BaseDatabase.cs
@@ -11,7 +11,7 @@ namespace Snowflake.Utility
     public abstract class BaseDatabase
     {
         public string FileName { get; private set; }
-        protected SQLiteConnection DBConnection { get; set; }
+        private readonly string DBConnectionString;
         public BaseDatabase(string fileName)
         {
             this.FileName = fileName;
@@ -20,7 +20,11 @@ namespace Snowflake.Utility
             {
                 SQLiteConnection.CreateFile(this.FileName);
             }
-            this.DBConnection = new SQLiteConnection("Data Source=" + this.FileName + ";Version=3;");
+            this.DBConnectionString = "Data Source=" + this.FileName + ";Version=3;";
+        }
+        public SQLiteConnection GetConnection()
+        {
+            return new SQLiteConnection(this.DBConnectionString);
         }
     }
 }

--- a/Snowflake/Controller/ControllerPortsDatabase.cs
+++ b/Snowflake/Controller/ControllerPortsDatabase.cs
@@ -20,7 +20,8 @@ namespace Snowflake.Controller
 
         private void CreateDatabase()
         {
-            this.DBConnection.Open();
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
             var sqlCommand = new SQLiteCommand(@"CREATE TABLE IF NOT EXISTS ports(
                                                                 platform_id TEXT PRIMARY KEY,
                                                                 port1 TEXT,
@@ -31,14 +32,15 @@ namespace Snowflake.Controller
                                                                 port6 TEXT,
                                                                 port7 TEXT,
                                                                 port8 TEXT
-                                                                )", this.DBConnection);
+                                                                )", dbConnection);
             sqlCommand.ExecuteNonQuery();
-            this.DBConnection.Close();
+            dbConnection.Close();
         }
 
         public void AddPlatform(IPlatformInfo platformInfo)
         {
-            this.DBConnection.Open();
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
             using (var sqlCommand = new SQLiteCommand(@"INSERT OR IGNORE INTO ports VALUES(
                                                                 @platform_id,
                                                                 null,
@@ -49,11 +51,11 @@ namespace Snowflake.Controller
                                                                 null,
                                                                 null,
                                                                 null
-                                                                )", this.DBConnection))
+                                                                )", dbConnection))
             {
                 sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformID);
                 sqlCommand.ExecuteNonQuery();
-                this.DBConnection.Close();
+                dbConnection.Close();
             }/*
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
@@ -69,9 +71,9 @@ namespace Snowflake.Controller
             if (portNumber > 8 || portNumber < 1){
                 return String.Empty;
             }
-           
-            this.DBConnection.Open();
-            using (var sqlCommand = new SQLiteCommand("SELECT `%portNumber` FROM `ports` WHERE `platform_id` == @platformId", this.DBConnection))
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
+            using (var sqlCommand = new SQLiteCommand("SELECT `%portNumber` FROM `ports` WHERE `platform_id` == @platformId", dbConnection))
             {
                 sqlCommand.CommandText = sqlCommand.CommandText.Replace("%portNumber", "port"+portNumber);
                 sqlCommand.Parameters.AddWithValue("@platformId", platformInfo.PlatformID);
@@ -80,7 +82,7 @@ namespace Snowflake.Controller
                     var result = new DataTable();
                     result.Load(reader);
                     var row = result.Rows[0];
-                    this.DBConnection.Close();
+                    dbConnection.Close();
                     return row.Field<string>("port"+portNumber);
                 }
             }
@@ -88,19 +90,20 @@ namespace Snowflake.Controller
 
         public void SetDeviceInPort(IPlatformInfo platformInfo, int portNumber, string deviceName)
         {
+            SQLiteConnection dbConnection = this.GetConnection();
             if (portNumber > 8 || portNumber < 1)
             {
                 throw new IndexOutOfRangeException("Snowflake only supports consoles up to 8 controller ports");
             }
-            this.DBConnection.Open();
-            using (var sqlCommand = new SQLiteCommand("UPDATE `ports` SET `%portNumber` = @controllerId WHERE `platform_id` == @platformId", this.DBConnection))
+            dbConnection.Open();
+            using (var sqlCommand = new SQLiteCommand("UPDATE `ports` SET `%portNumber` = @controllerId WHERE `platform_id` == @platformId", dbConnection))
             {
                 sqlCommand.CommandText = sqlCommand.CommandText.Replace("%portNumber", "port" + portNumber);
                 sqlCommand.Parameters.AddWithValue("@controllerId", deviceName);
                 sqlCommand.Parameters.AddWithValue("@platformId", platformInfo.PlatformID);
                 sqlCommand.ExecuteNonQuery();
             }
-            this.DBConnection.Close();
+            dbConnection.Close();
         }
 
         private void SetDefaults_Win32(IPlatformInfo platformInfo)

--- a/Snowflake/Controller/ControllerProfile.cs
+++ b/Snowflake/Controller/ControllerProfile.cs
@@ -5,6 +5,8 @@ using System.Text;
 using System.Threading.Tasks;
 using Snowflake.Emulator.Input;
 using Snowflake.Extensions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Snowflake.Controller
 {
@@ -12,6 +14,7 @@ namespace Snowflake.Controller
     {
         public IDictionary<string, string> InputConfiguration { get; private set; }
         public string ControllerID { get; private set; }
+        [JsonConverter(typeof(StringEnumConverter))]
         public ControllerProfileType ProfileType { get; private set; }
         public ControllerProfile(string controllerId, ControllerProfileType profileType, IDictionary<string, string> inputConfiguration)
         {

--- a/Snowflake/Controller/ControllerProfileStore.cs
+++ b/Snowflake/Controller/ControllerProfileStore.cs
@@ -27,6 +27,7 @@ namespace Snowflake.Controller
         }
         public IControllerProfile GetControllerProfile(string deviceName)
         {
+            if (deviceName == null) deviceName = "null";
             return ControllerProfile.FromJsonProtoTemplate(
                 JsonConvert.DeserializeObject<IDictionary<string, dynamic>>(
                     File.ReadAllText(this.GetControllerProfileFilename(deviceName))));

--- a/Snowflake/Emulator/Configuration/ConfigurationFlagStore.cs
+++ b/Snowflake/Emulator/Configuration/ConfigurationFlagStore.cs
@@ -88,6 +88,7 @@ namespace Snowflake.Emulator.Configuration
             {
                 case ConfigurationFlagTypes.SELECT_FLAG:
                     return Int32.Parse(value);
+
                 case ConfigurationFlagTypes.INTEGER_FLAG:
                     return Int32.Parse(value);
                 case ConfigurationFlagTypes.BOOLEAN_FLAG:
@@ -109,7 +110,12 @@ namespace Snowflake.Emulator.Configuration
         }
         private string GetCacheFileName(IGameInfo gameInfo)
         {
-            return Path.Combine(this.configurationFlagLocation, String.Format("{0}.{1}.cfg", gameInfo.UUID, this.EmulatorBridgeID));
+            try
+            {
+                return Path.Combine(this.configurationFlagLocation, String.Format("{0}.{1}.cfg", gameInfo.UUID, this.EmulatorBridgeID));
+            }catch{
+                return String.Empty;
+            }
         }
         private string GetDefaultFileName()
         {

--- a/Snowflake/Emulator/EmulatorBridge.cs
+++ b/Snowflake/Emulator/EmulatorBridge.cs
@@ -84,6 +84,7 @@ namespace Snowflake.Emulator
 
         public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IControllerProfile controllerProfile, IInputTemplate inputTemplate)
         {
+            if (controllerProfile.ProfileType == ControllerProfileType.NULL_PROFILE) return String.Empty;
             var controllerMappings = controllerProfile.ProfileType == ControllerProfileType.KEYBOARD_PROFILE ?
                 controllerTemplate.KeyboardControllerMappings : controllerTemplate.GamepadControllerMappings;
             return this.CompileController(playerIndex, platformInfo, controllerDefinition, controllerTemplate, controllerProfile, inputTemplate, controllerMappings);
@@ -91,6 +92,7 @@ namespace Snowflake.Emulator
 
         public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IControllerProfile controllerProfile, IInputTemplate inputTemplate, IReadOnlyDictionary<string, IControllerMapping> controllerMappings)
         {
+            if (controllerProfile.ProfileType == ControllerProfileType.NULL_PROFILE) return String.Empty;
             var template = new StringBuilder(inputTemplate.StringTemplate);
             foreach (IControllerInput input in controllerDefinition.ControllerInputs.Values)
             {

--- a/Snowflake/Game/GameDatabase.cs
+++ b/Snowflake/Game/GameDatabase.cs
@@ -90,8 +90,16 @@ namespace Snowflake.Game
                 using (var reader = sqlCommand.ExecuteReader())
                 {
                     var result = new DataTable();
-                    lock (result) {
-                        result.Load(reader);
+                    lock (reader) {
+                        try
+                        {
+                            result.Load(reader);
+                        }
+                        catch (AccessViolationException)
+                        {
+                            System.Threading.Thread.Sleep(500);
+                            result.Load(reader);
+                        }
                         var gamesResults = (from DataRow row in result.Rows select GetGameFromDataRow(row)).ToList();
                         this.DBConnection.Close();
                         return gamesResults;

--- a/Snowflake/Game/GameDatabase.cs
+++ b/Snowflake/Game/GameDatabase.cs
@@ -24,7 +24,8 @@ namespace Snowflake.Game
 
         private void CreateDatabase()
         {
-            this.DBConnection.Open();
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
             var sqlCommand = new SQLiteCommand(@"CREATE TABLE IF NOT EXISTS games(
                                                                 platform_id TEXT,
                                                                 uuid TEXT PRIMARY KEY,
@@ -32,21 +33,22 @@ namespace Snowflake.Game
                                                                 name TEXT,
                                                                 metadata TEXT,
                                                                 crc32 TEXT
-                                                                )", this.DBConnection);
+                                                                )", dbConnection);
             sqlCommand.ExecuteNonQuery();
-            this.DBConnection.Close();
+            dbConnection.Close();
         }
 
         public void AddGame(IGameInfo game)
         {
-            this.DBConnection.Open();
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
             using (var sqlCommand = new SQLiteCommand(@"INSERT OR REPLACE INTO games VALUES(
                                           @platform_id,
                                           @uuid,
                                           @filename,
                                           @name,
                                           @metadata,
-                                          @crc32)", this.DBConnection))
+                                          @crc32)", dbConnection))
             {
                 sqlCommand.Parameters.AddWithValue("@platform_id", game.PlatformID);
                 sqlCommand.Parameters.AddWithValue("@uuid", game.UUID);
@@ -56,7 +58,7 @@ namespace Snowflake.Game
                 sqlCommand.Parameters.AddWithValue("@crc32", game.CRC32);
                 sqlCommand.ExecuteNonQuery();
             }
-            this.DBConnection.Close();
+            dbConnection.Close();
         }
 
         public IGameInfo GetGameByUUID(string uuid)
@@ -81,9 +83,10 @@ namespace Snowflake.Game
         }
         private IList<IGameInfo> GetGamesByColumn(string colName, string searchQuery)
         {
-            this.DBConnection.Open();
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
             using (var sqlCommand = new SQLiteCommand(@"SELECT * FROM `games` WHERE `%colName` == @searchQuery"
-                , this.DBConnection))
+                , dbConnection))
             {
                 sqlCommand.CommandText = sqlCommand.CommandText.Replace("%colName", colName); //Easier to read than string replacement.
                 sqlCommand.Parameters.AddWithValue("@searchQuery", searchQuery);
@@ -101,7 +104,7 @@ namespace Snowflake.Game
                             result.Load(reader);
                         }
                         var gamesResults = (from DataRow row in result.Rows select GetGameFromDataRow(row)).ToList();
-                        this.DBConnection.Close();
+                        dbConnection.Close();
                         return gamesResults;
                     }
                 }
@@ -109,16 +112,17 @@ namespace Snowflake.Game
         }
         public IList<IGameInfo> GetAllGames()
         {
-            this.DBConnection.Open();
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
             using (var sqlCommand = new SQLiteCommand(@"SELECT * FROM `games`"
-                , this.DBConnection))
+                , dbConnection))
             {
                 using (var reader = sqlCommand.ExecuteReader())
                 {
                     var result = new DataTable();
                     result.Load(reader);
                     var gamesResults = (from DataRow row in result.Rows select this.GetGameFromDataRow(row)).ToList();
-                    this.DBConnection.Close();
+                    dbConnection.Close();
                     return gamesResults;
                 }
             }

--- a/Snowflake/Platform/PlatformPreferencesDatabase.cs
+++ b/Snowflake/Platform/PlatformPreferencesDatabase.cs
@@ -22,21 +22,23 @@ namespace Snowflake.Platform
         }
         private void CreateDatabase()
         {
-            this.DBConnection.Open();
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
             var sqlCommand = new SQLiteCommand(@"CREATE TABLE IF NOT EXISTS platformprefs(
                                                                 platform_id TEXT PRIMARY KEY,
                                                                 emulator TEXT,
-                                                                scraper TEXT)", this.DBConnection);
+                                                                scraper TEXT)", dbConnection);
             sqlCommand.ExecuteNonQuery();
-            this.DBConnection.Close();
+            dbConnection.Close();
         }
         public void AddPlatform(IPlatformInfo platformInfo)
         {
-            this.DBConnection.Open();
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
             using (var sqlCommand = new SQLiteCommand(@"INSERT OR IGNORE INTO platformprefs VALUES(
                                           @platform_id,
                                           @emulator,
-                                          @scraper)", this.DBConnection))
+                                          @scraper)", dbConnection))
             {
                 sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformID);
                 KeyValuePair<string, IEmulatorBridge> emulator = pluginManager.LoadedEmulators.Where(x => x.Value.SupportedPlatforms.Contains(platformInfo.PlatformID)).FirstOrDefault();
@@ -47,14 +49,15 @@ namespace Snowflake.Platform
                 sqlCommand.Parameters.AddWithValue("@scraper", scraperId);
                 sqlCommand.ExecuteNonQuery();
             }
-            this.DBConnection.Close();
+            dbConnection.Close();
 
         }
         public IPlatformDefaults GetPreferences(IPlatformInfo platformInfo)
         {
-            this.DBConnection.Open();
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
             using (var sqlCommand = new SQLiteCommand(@"SELECT * FROM `platformprefs` WHERE `platform_id` == @platform_id"
-                , this.DBConnection))
+                , dbConnection))
             {
                 sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformID);
                 using (var reader = sqlCommand.ExecuteReader())
@@ -66,7 +69,7 @@ namespace Snowflake.Platform
                     string emulator = result.Rows[0].Field<string>("emulator");
                     IPlatformDefaults platformDefaults =
                         new PlatformDefaults(scraper,  emulator);
-                    this.DBConnection.Close();
+                    dbConnection.Close();
                     return platformDefaults;
                 }
             }
@@ -81,8 +84,9 @@ namespace Snowflake.Platform
         }
         private void SetColumn(IPlatformInfo platformInfo, string column, string value)
         {
-            this.DBConnection.Open();
-            using (var sqlCommand = new SQLiteCommand("UPDATE `platformprefs` SET `%colName` = @value WHERE `platform_id` == @platform_id", this.DBConnection))
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
+            using (var sqlCommand = new SQLiteCommand("UPDATE `platformprefs` SET `%colName` = @value WHERE `platform_id` == @platform_id", dbConnection))
             {
                 sqlCommand.CommandText = sqlCommand.CommandText.Replace("%colName", column);
 
@@ -90,7 +94,7 @@ namespace Snowflake.Platform
                 sqlCommand.Parameters.AddWithValue("@platform_id", platformInfo.PlatformID);
                 sqlCommand.ExecuteNonQuery();
             }
-            this.DBConnection.Close();
+            dbConnection.Close();
         }
 
     }


### PR DESCRIPTION
This PR makes the following changes

* ControllerProfileStore implements a null profile for controllers not recognized by a system and unfilled ports
* BaseDatabase moves from a single connection model to a multiple connection model that returns a new connection every time. This prevents any InvalidOperationExceptions when accessing the database