### PR TITLE
ConfigurationFlagStore: Use a SQLite database to store flags

### DIFF
--- a/Snowflake.API/Snowflake.API.csproj
+++ b/Snowflake.API/Snowflake.API.csproj
@@ -157,7 +157,6 @@
     <Compile Include="Utility\Hash\SHA1.cs" />
     <Compile Include="Utility\StringEncode.cs" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <Content Include="x86\SQLite.Interop.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Snowflake.API/Utility/BaseDatabase.cs
+++ b/Snowflake.API/Utility/BaseDatabase.cs
@@ -20,7 +20,7 @@ namespace Snowflake.Utility
             {
                 SQLiteConnection.CreateFile(this.FileName);
             }
-            this.DBConnectionString = "Data Source=" + this.FileName + ";Version=3;";
+            this.DBConnectionString = "Data Source=" + this.FileName + ";Version=3;PRAGMA journal_mode=WAL;";
         }
         public SQLiteConnection GetConnection()
         {

--- a/Snowflake.Core.Init/App.config
+++ b/Snowflake.Core.Init/App.config
@@ -26,4 +26,12 @@
       <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
     </providers>
   </entityFramework>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Snowflake.Core.Init/Form1.cs
+++ b/Snowflake.Core.Init/Form1.cs
@@ -39,7 +39,7 @@ namespace Snowflake.Service.Init
         public Form1()
         {
             InitializeComponent();
-            Console.SetOut(new MultiTextWriter(new ControlWriter(this.textBox1, this), Console.Out));
+            //Console.SetOut(new MultiTextWriter(new ControlWriter(this.textBox1, this), Console.Out));
             start();
 
  string x_ = @"

--- a/Snowflake.Service/app.config
+++ b/Snowflake.Service/app.config
@@ -23,4 +23,12 @@
       <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
     </providers>
   </entityFramework>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Snowflake.StandardAjax/Snowflake.StandardAjax.csproj
+++ b/Snowflake.StandardAjax/Snowflake.StandardAjax.csproj
@@ -82,6 +82,7 @@
     <Compile Include="StandardAjax.System.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <Compile Include="StandardAjax.GameCache.cs" />
   </ItemGroup>

--- a/Snowflake.StandardAjax/app.config
+++ b/Snowflake.StandardAjax/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Snowflake.Tests/Snowflake.Tests.csproj
+++ b/Snowflake.Tests/Snowflake.Tests.csproj
@@ -111,6 +111,7 @@
     <EmbeddedResource Include="..\Platforms\NINTENDO_SNES.platform">
       <Link>TestResources\Platforms\NINTENDO_SNES.platform</Link>
     </EmbeddedResource>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <EmbeddedResource Include="TestResources\ControllerProfiles\NES_CONTROLLER\KeyboardDevice-NES_CONTROLLER.json" />
     <EmbeddedResource Include="TestResources\ControllerProfiles\NES_CONTROLLER\XInputDevice1-NES_CONTROLLER.json" />

--- a/Snowflake.Tests/app.config
+++ b/Snowflake.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Snowflake/Emulator/Configuration/ConfigurationFlagStore.cs
+++ b/Snowflake/Emulator/Configuration/ConfigurationFlagStore.cs
@@ -7,36 +7,52 @@ using System.IO;
 using Snowflake.Game;
 using Newtonsoft.Json;
 using Snowflake.Service;
-
+using Snowflake.Utility;
+using System.Data.SQLite;
 namespace Snowflake.Emulator.Configuration
 {
-    public class ConfigurationFlagStore : IConfigurationFlagStore
+    public class ConfigurationFlagStore : BaseDatabase, IConfigurationFlagStore
     {
         public string EmulatorBridgeID { get; private set; }
         readonly string configurationFlagLocation;
         readonly IEmulatorBridge emulatorBridge;
         public ConfigurationFlagStore(IEmulatorBridge emulatorBridge)
+            : base(Path.Combine(emulatorBridge.PluginDataPath, "flagscache.db"))
         {
+            this.CreateDatabase();
             this.EmulatorBridgeID = emulatorBridge.PluginName;
-            this.emulatorBridge = emulatorBridge;
-            this.configurationFlagLocation = Path.Combine(emulatorBridge.PluginDataPath, "flagscache");
-            if (!Directory.Exists(configurationFlagLocation)) Directory.CreateDirectory(configurationFlagLocation);
+            this.configurationFlagLocation = Path.Combine(emulatorBridge.PluginDataPath, "flagscache.db");
             this.AddDefaults(emulatorBridge.ConfigurationFlags);
+            this.emulatorBridge = emulatorBridge;
         }
-        private void AddDefaults(IDictionary<string, IConfigurationFlag> configurationFlags)
+        private void CreateDatabase()
         {
-            IDictionary<string, string> flagValues = configurationFlags.ToDictionary(flag => flag.Key, flag => flag.Value.DefaultValue);
-            if (!File.Exists(this.GetDefaultFileName()))
-            {
-                File.WriteAllText(this.GetDefaultFileName(), JsonConvert.SerializeObject(flagValues));
-            }
+            SQLiteConnection dbConnection = this.GetConnection();
+            dbConnection.Open();
+            var sqlCommand = new SQLiteCommand(@"CREATE TABLE IF NOT EXISTS flags(
+                                                                flagKey TEXT PRIMARY KEY,
+                                                                flagValue TEXT)", dbConnection);
+            sqlCommand.ExecuteNonQuery();
+            dbConnection.Close();
         }
         public void AddGame(IGameInfo gameInfo, IDictionary<string, string> flagValues)
         {
-            if (!File.Exists(this.GetCacheFileName(gameInfo)))
+
+
+            var flagDb = this.GetConnection();
+            flagDb.Open();
+            foreach (KeyValuePair<string, string> flagPair in flagValues)
             {
-                File.WriteAllText(this.GetCacheFileName(gameInfo), JsonConvert.SerializeObject(flagValues));
+                using (var sqliteCommand = new SQLiteCommand(@"INSERT OR REPLACE INTO flags VALUES(
+                                          @flagKey,
+                                          @flagValue)", flagDb))
+                {
+                    sqliteCommand.Parameters.AddWithValue("@flagKey", gameInfo.UUID + flagPair.Key);
+                    sqliteCommand.Parameters.AddWithValue("@flagValue", flagPair.Value.ToString());
+                    sqliteCommand.ExecuteNonQuery();
+                }
             }
+            flagDb.Close();
         }
         public void AddGame(IGameInfo gameInfo)
         {
@@ -45,42 +61,78 @@ namespace Snowflake.Emulator.Configuration
         }
         public dynamic GetValue(IGameInfo gameInfo, string key, ConfigurationFlagTypes type)
         {
-            return this.GetValue(key, type, this.GetCacheFileName(gameInfo), this.GetDefaultValue(key, type));
+            return this.GetValue(key, type, gameInfo.UUID, this.GetDefaultValue(key, type));
         }
         public void SetValue(IGameInfo gameInfo, string key, object value, ConfigurationFlagTypes type)
         {
-            this.SetValue(key, value, type, this.GetCacheFileName(gameInfo));
+            this.SetValue(key, value, type, gameInfo.UUID);
         }
         public dynamic GetDefaultValue(string key, ConfigurationFlagTypes type)
         {
-            return this.GetValue(key, type, this.GetDefaultFileName(), this.emulatorBridge.ConfigurationFlags[key].DefaultValue);
+            return this.GetValue(key, type, "default", this.emulatorBridge.ConfigurationFlags[key].DefaultValue);
         }
         public void SetDefaultValue(string key, object value, ConfigurationFlagTypes type)
         {
-            this.SetValue(key, value, type, this.GetDefaultFileName());
+            this.SetValue(key, value, type, "default");
         }
-        private void SetValue(string key, object value, ConfigurationFlagTypes type, string filename)
+        private void AddDefaults(IDictionary<string, IConfigurationFlag> configurationFlags)
         {
-            IDictionary<string, string> keys;
-            try
+            IDictionary<string, string> flagValues = configurationFlags.ToDictionary(flag => flag.Key, flag => flag.Value.DefaultValue);
+            var flagDb = this.GetConnection();
+            flagDb.Open();
+            foreach (KeyValuePair<string, string> flagPair in flagValues)
             {
-               keys = JsonConvert.DeserializeObject<IDictionary<string, string>>(File.ReadAllText(filename));
+               using(var sqliteCommand = new SQLiteCommand(@"INSERT OR REPLACE INTO flags VALUES(
+                                          @flagKey,
+                                          @flagValue)", flagDb)){
+                   sqliteCommand.Parameters.AddWithValue("@flagKey", "default-"+flagPair.Key);
+                   sqliteCommand.Parameters.AddWithValue("@flagValue", flagPair.Value.ToString());
+                   sqliteCommand.ExecuteNonQuery();
+               }
             }
-            catch
-            {
-               keys = new Dictionary<string, string>();
-            }
-            keys[key] = value.ToString();
-            File.WriteAllText(filename, JsonConvert.SerializeObject(keys));
+            flagDb.Close();
+            
+
         }
-        private dynamic GetValue(string key, ConfigurationFlagTypes type, string filename, object fallback)
+        private void SetValue(string key, object value, ConfigurationFlagTypes type, string prefix)
         {
+            var flagDb = this.GetConnection();
+            flagDb.Open();
+            using (var sqliteCommand = new SQLiteCommand(@"INSERT OR REPLACE INTO flags VALUES(
+                                          @flagKey,
+                                          @flagValue)", flagDb))
+            {
+                sqliteCommand.Parameters.AddWithValue("@flagKey", prefix + "-" + key);
+                sqliteCommand.Parameters.AddWithValue("@flagValue", value.ToString());
+                sqliteCommand.ExecuteNonQuery();
+            }
+            flagDb.Close();
+            
+        }
+        private dynamic GetValue(string key, ConfigurationFlagTypes type, string prefix, object fallback)
+        {
+            var dbConnection = this.GetConnection();
+            dbConnection.Open();
             string value = String.Empty;
-            try
+            using (var sqlCommand = new SQLiteCommand(@"SELECT `flagValue` FROM `flags` WHERE `flagKey` == @searchQuery"
+               , dbConnection))
             {
-                value = JsonConvert.DeserializeObject<IDictionary<string, string>>(File.ReadAllText(filename))[key];
+                sqlCommand.Parameters.AddWithValue("@searchQuery", prefix + "-" + key);
+                
+                    try
+                    {
+                        value = (string)sqlCommand.ExecuteScalar();
+                    }
+                    catch (AccessViolationException)
+                    {
+                        System.Threading.Thread.Sleep(500); //le concurrency hack :(
+                        value = (string)sqlCommand.ExecuteScalar();
+                    }
+                   
+                
             }
-            catch
+            dbConnection.Close();
+            if (value == null)
             {
                 value = fallback.ToString();
             }
@@ -88,7 +140,6 @@ namespace Snowflake.Emulator.Configuration
             {
                 case ConfigurationFlagTypes.SELECT_FLAG:
                     return Int32.Parse(value);
-
                 case ConfigurationFlagTypes.INTEGER_FLAG:
                     return Int32.Parse(value);
                 case ConfigurationFlagTypes.BOOLEAN_FLAG:
@@ -97,6 +148,7 @@ namespace Snowflake.Emulator.Configuration
                     return value;
             }
         }
+
         public dynamic this[IGameInfo gameInfo, string key, ConfigurationFlagTypes type]
         {
             get
@@ -107,19 +159,6 @@ namespace Snowflake.Emulator.Configuration
             {
                 this.SetValue(gameInfo, key, value, type);
             }
-        }
-        private string GetCacheFileName(IGameInfo gameInfo)
-        {
-            try
-            {
-                return Path.Combine(this.configurationFlagLocation, String.Format("{0}.{1}.cfg", gameInfo.UUID, this.EmulatorBridgeID));
-            }catch{
-                return String.Empty;
-            }
-        }
-        private string GetDefaultFileName()
-        {
-            return Path.Combine(this.configurationFlagLocation, String.Format("{0}.{1}.cfg", "default", this.EmulatorBridgeID));
         }
     }
 }

--- a/Snowflake/Emulator/Configuration/ConfigurationFlagStore.cs
+++ b/Snowflake/Emulator/Configuration/ConfigurationFlagStore.cs
@@ -102,10 +102,12 @@ namespace Snowflake.Emulator.Configuration
                                           @flagKey,
                                           @flagValue)", flagDb))
             {
+                Console.WriteLine("Setting value " + value + " for key " + key + " for prefix " + prefix);
                 sqliteCommand.Parameters.AddWithValue("@flagKey", prefix + "-" + key);
                 sqliteCommand.Parameters.AddWithValue("@flagValue", value.ToString());
                 sqliteCommand.ExecuteNonQuery();
             }
+            Console.WriteLine("Commit value " + value + " for key " + key + " for prefix " + prefix);
             flagDb.Close();
             
         }
@@ -118,7 +120,7 @@ namespace Snowflake.Emulator.Configuration
                , dbConnection))
             {
                 sqlCommand.Parameters.AddWithValue("@searchQuery", prefix + "-" + key);
-                
+               
                     try
                     {
                         value = (string)sqlCommand.ExecuteScalar();
@@ -128,14 +130,15 @@ namespace Snowflake.Emulator.Configuration
                         System.Threading.Thread.Sleep(500); //le concurrency hack :(
                         value = (string)sqlCommand.ExecuteScalar();
                     }
-                   
-                
+                    Console.WriteLine("Received value " + value + " for key " + key + " for prefix " + prefix);
             }
             dbConnection.Close();
             if (value == null)
             {
                 value = fallback.ToString();
             }
+            Console.WriteLine("Final value " + value + " for key " + key + " for prefix " + prefix);
+
             switch (type)
             {
                 case ConfigurationFlagTypes.SELECT_FLAG:

--- a/Snowflake/Emulator/Configuration/ConfigurationFlagStore.cs.orig
+++ b/Snowflake/Emulator/Configuration/ConfigurationFlagStore.cs.orig
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using Snowflake.Game;
+using Newtonsoft.Json;
+using Snowflake.Service;
+using RaptorDB;
+namespace Snowflake.Emulator.Configuration
+{
+    public class ConfigurationFlagStore : IConfigurationFlagStore
+    {
+        public string EmulatorBridgeID { get; private set; }
+        readonly string configurationFlagLocation;
+        readonly IEmulatorBridge emulatorBridge;
+        public ConfigurationFlagStore(IEmulatorBridge emulatorBridge)
+        {
+            this.EmulatorBridgeID = emulatorBridge.PluginName;
+            this.emulatorBridge = emulatorBridge;
+            this.configurationFlagLocation = Path.Combine(emulatorBridge.PluginDataPath, "flagscache");
+            if (!Directory.Exists(configurationFlagLocation)) Directory.CreateDirectory(configurationFlagLocation);
+            this.AddDefaults(emulatorBridge.ConfigurationFlags);
+        }
+       
+        public void AddGame(IGameInfo gameInfo, IDictionary<string, string> flagValues)
+        {
+            RaptorDB<string> flagDb = this.GetDB(this.GetCacheFileName(gameInfo));
+            foreach(KeyValuePair<string, string> flagPair in flagValues){
+                flagDb.Set(flagPair.Key, flagPair.Value);
+            }
+            flagDb.Shutdown();
+        }
+        public void AddGame(IGameInfo gameInfo)
+        {
+            IDictionary<string, string> flagValues = new Dictionary<string, string>();
+            this.AddGame(gameInfo, flagValues);
+        }
+        public dynamic GetValue(IGameInfo gameInfo, string key, ConfigurationFlagTypes type)
+        {
+            return this.GetValue(key, type, this.GetCacheFileName(gameInfo), this.GetDefaultValue(key, type));
+        }
+        public void SetValue(IGameInfo gameInfo, string key, object value, ConfigurationFlagTypes type)
+        {
+            this.SetValue(key, value, type, this.GetCacheFileName(gameInfo));
+        }
+        public dynamic GetDefaultValue(string key, ConfigurationFlagTypes type)
+        {
+            return this.GetValue(key, type, this.GetDefaultFileName(), this.emulatorBridge.ConfigurationFlags[key].DefaultValue);
+        }
+        public void SetDefaultValue(string key, object value, ConfigurationFlagTypes type)
+        {
+            this.SetValue(key, value, type, this.GetDefaultFileName());
+        }
+        private void AddDefaults(IDictionary<string, IConfigurationFlag> configurationFlags)
+        {
+            IDictionary<string, string> flagValues = configurationFlags.ToDictionary(flag => flag.Key, flag => flag.Value.DefaultValue);
+            RaptorDB<string> flagDb = this.GetDB(this.GetDefaultFileName());
+            foreach (KeyValuePair<string, string> flagPair in flagValues)
+            {
+                flagDb.Set(flagPair.Key, flagPair.Value);
+            }
+            flagDb.Shutdown();
+        }
+        private void SetValue(string key, object value, ConfigurationFlagTypes type, string filename)
+        {
+            RaptorDB<string> flagDb = this.GetDB(filename);
+            flagDb.Set(key, value.ToString());
+            flagDb.Shutdown();
+        }
+        private dynamic GetValue(string key, ConfigurationFlagTypes type, string filename, object fallback)
+        {
+            string value = String.Empty;
+            RaptorDB<string> flagDb = this.GetDB(filename);
+            if (!flagDb.Get(key, out value))
+            {
+                value = fallback.ToString();
+            }
+            flagDb.Shutdown();
+            switch (type)
+            {
+                case ConfigurationFlagTypes.SELECT_FLAG:
+                    return Int32.Parse(value);
+
+                case ConfigurationFlagTypes.INTEGER_FLAG:
+                    return Int32.Parse(value);
+                case ConfigurationFlagTypes.BOOLEAN_FLAG:
+                    return Boolean.Parse(value);
+                default:
+                    return value;
+            }
+        }
+
+        RaptorDB<string> GetDB(string dbFileName)
+        {
+            return RaptorDB.RaptorDB<string>.Open(dbFileName, true);
+        }
+        public dynamic this[IGameInfo gameInfo, string key, ConfigurationFlagTypes type]
+        {
+            get
+            {
+                return this.GetValue(gameInfo, key, type);
+            }
+            set
+            {
+                this.SetValue(gameInfo, key, value, type);
+            }
+        }
+        private string GetCacheFileName(IGameInfo gameInfo)
+        {
+<<<<<<< Updated upstream
+            try
+            {
+                return Path.Combine(this.configurationFlagLocation, String.Format("{0}.{1}.cfg", gameInfo.UUID, this.EmulatorBridgeID));
+            }catch{
+                return String.Empty;
+            }
+=======
+            return Path.Combine(this.configurationFlagLocation, String.Format("{0}.{1}.db", gameInfo.UUID, this.EmulatorBridgeID));
+>>>>>>> Stashed changes
+        }
+        private string GetDefaultFileName()
+        {
+            return Path.Combine(this.configurationFlagLocation, String.Format("{0}.{1}.db", "default", this.EmulatorBridgeID));
+        }
+    }
+}

--- a/Snowflake/app.config
+++ b/Snowflake/app.config
@@ -1,26 +1,35 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <system.data>
     <DbProviderFactories>
-      <remove invariant="System.Data.SQLite"/>
-      <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".Net Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite"/>
-      <remove invariant="System.Data.SQLite.EF6"/>
-      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".Net Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6"/>
+      <remove invariant="System.Data.SQLite" />
+      <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".Net Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
+      <remove invariant="System.Data.SQLite.EF6" />
+      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".Net Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
     </DbProviderFactories>
   </system.data>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
-        <parameter value="v11.0"/>
+        <parameter value="v11.0" />
       </parameters>
     </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
-      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6"/>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
     </providers>
   </entityFramework>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Snowflake/packages.config
+++ b/Snowflake/packages.config
@@ -10,4 +10,5 @@
   <package id="System.Data.SQLite.Core" version="1.0.93.0" targetFramework="net45" />
   <package id="System.Data.SQLite.EF6" version="1.0.93.0" targetFramework="net45" />
   <package id="System.Data.SQLite.Linq" version="1.0.93.0" targetFramework="net45" />
+  <package id="System.Data.Unqlite.dll" version="1.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Rather than a JSON file for every game, this commit switches ConfigurationFlagStore to use a SQLite database as a KeyValue store. This is more reliable and SQLite is able to handle concurrent writes better than just dumping JSON data into a file.