### PR TITLE
[Events] SnowflakeEventSource improvements

### DIFF
--- a/Snowflake.Events/Snowflake.Events.csproj
+++ b/Snowflake.Events/Snowflake.Events.csproj
@@ -71,7 +71,7 @@
     <Compile Include="ServiceEvents\ServerStopEventArgs.cs" />
     <Compile Include="SnowflakeEventArgs.cs" />
     <Compile Include="SnowflakeEventManager.cs" />
-    <Compile Include="SnowflakeEventSource.cs" />
+    <Compile Include="StandardEvents.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Snowflake.Events/SnowflakeEventManager.cs
+++ b/Snowflake.Events/SnowflakeEventManager.cs
@@ -34,7 +34,7 @@ namespace Snowflake.Events
             if (SnowflakeEventManager.EventSource == null)
             {
                 SnowflakeEventManager.EventSource = new SnowflakeEventManager();
-                var stdEvents = new SnowflakeEventSource();
+                var stdEvents = new StandardEvents();
                 stdEvents.RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
             }
         }

--- a/Snowflake.Events/StandardEvents.cs
+++ b/Snowflake.Events/StandardEvents.cs
@@ -10,7 +10,7 @@ using Snowflake.Events.ServiceEvents;
 
 namespace Snowflake.Events
 {
-    public class SnowflakeEventSource
+    public class StandardEvents
     {
         public void RegisterSnowflakeEvents(ISnowflakeEventManager eventManager)
         {

--- a/Snowflake.Tests/Events/SnowflakeEventManagerTests.cs
+++ b/Snowflake.Tests/Events/SnowflakeEventManagerTests.cs
@@ -48,7 +48,6 @@ namespace Snowflake.Events.Test
         {
             SnowflakeEventManager.InitEventSource();
             SnowflakeEventManager.EventSource.RegisterEvent<SnowflakeEventArgs>(null);
-           
             SnowflakeEventManager.EventSource.Subscribe<SnowflakeEventArgs>(this.handleEvent);
             Assert.NotNull(SnowflakeEventManager.EventSource.GetEvent<SnowflakeEventArgs>());
             SnowflakeEventManager.EventSource.Unsubscribe<SnowflakeEventArgs>(this.handleEvent);

--- a/Snowflake.Tests/Events/StandardEventsTests.cs
+++ b/Snowflake.Tests/Events/StandardEventsTests.cs
@@ -1,0 +1,264 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Snowflake.Events;
+using Snowflake.Events.CoreEvents.GameEvent;
+using Snowflake.Events.CoreEvents.ModifyEvent;
+using Snowflake.Events.ServiceEvents;
+using Snowflake.Service;
+using Snowflake.Game;
+using Snowflake.Platform;
+using Snowflake.Emulator;
+using Snowflake.Scraper;
+using Snowflake.Emulator.Configuration;
+using Snowflake.Emulator.Input;
+using Snowflake.Ajax;
+using Xunit;
+using Moq;
+namespace Snowflake.Events.Tests
+{
+
+    public class SnowflakeEventSourceTests
+    {
+
+        [Fact]
+        public void GameAddEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeGameInfo = new Mock<IGameInfo>();
+            var fakeGameDatabase = new Mock<IGameDatabase>();
+            var args = new GameAddEventArgs(fakeCoreService.Object, fakeGameInfo.Object, fakeGameDatabase.Object);
+            SnowflakeEventManager.EventSource.Subscribe<GameAddEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void GameDeleteEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeGameInfo = new Mock<IGameInfo>();
+            var fakeGameDatabase = new Mock<IGameDatabase>();
+            var args = new GameDeleteEventArgs(fakeCoreService.Object, fakeGameInfo.Object, fakeGameDatabase.Object);
+            SnowflakeEventManager.EventSource.Subscribe<GameDeleteEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void GameProcessQuitEventArgs_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeGameInfo = new Mock<IGameInfo>();
+            var fakeEmulatorAssembly = new Mock<IEmulatorAssembly>();
+            var fakeEmulatorBridge = new Mock<IEmulatorBridge>();
+            var args = new GameProcessQuitEventArgs(fakeCoreService.Object, fakeGameInfo.Object, fakeEmulatorAssembly.Object, fakeEmulatorBridge.Object, new System.Diagnostics.Process());
+            SnowflakeEventManager.EventSource.Subscribe<GameProcessQuitEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void GameProcessStartEventArgs_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeGameInfo = new Mock<IGameInfo>();
+            var fakeEmulatorAssembly = new Mock<IEmulatorAssembly>();
+            var fakeEmulatorBridge = new Mock<IEmulatorBridge>();
+            var args = new GameProcessStartEventArgs(fakeCoreService.Object, fakeGameInfo.Object, fakeEmulatorAssembly.Object, fakeEmulatorBridge.Object, new System.Diagnostics.Process());
+            SnowflakeEventManager.EventSource.Subscribe<GameProcessStartEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void GameQuitEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeGameInfo = new Mock<IGameInfo>();
+            var fakeEmulatorAssembly = new Mock<IEmulatorAssembly>();
+            var fakeEmulatorBridge = new Mock<IEmulatorBridge>();
+            var args = new GameQuitEventArgs(fakeCoreService.Object, fakeGameInfo.Object, fakeEmulatorAssembly.Object, fakeEmulatorBridge.Object);
+            SnowflakeEventManager.EventSource.Subscribe<GameQuitEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void GameStartEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeGameInfo = new Mock<IGameInfo>();
+            var fakeEmulatorAssembly = new Mock<IEmulatorAssembly>();
+            var fakeEmulatorBridge = new Mock<IEmulatorBridge>();
+            var args = new GameStartEventArgs(fakeCoreService.Object, fakeGameInfo.Object, fakeEmulatorAssembly.Object, fakeEmulatorBridge.Object);
+            SnowflakeEventManager.EventSource.Subscribe<GameStartEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void GameInfoScrapedEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeGameInfo = new Mock<IGameInfo>();
+            var fakeScraper = new Mock<IScraper>();
+            var args = new GameInfoScrapedEventArgs(fakeCoreService.Object, fakeGameInfo.Object, fakeScraper.Object);
+            SnowflakeEventManager.EventSource.Subscribe<GameInfoScrapedEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void GameScrapeResultsEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeScraper = new Mock<IScraper>();
+            var args = new GameResultsScrapedEventArgs(fakeCoreService.Object, "TEST", new List<Snowflake.Scraper.IGameScrapeResult>(), fakeScraper.Object);
+            SnowflakeEventManager.EventSource.Subscribe<GameResultsScrapedEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+
+        [Fact]
+        public void ModifyConfigurationFlagEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeConfiguration = new Mock<IConfigurationFlag>();
+            var args = new ModifyConfigurationFlagEventArgs(fakeCoreService.Object, new object(), new object(), fakeConfiguration.Object);
+            SnowflakeEventManager.EventSource.Subscribe<ModifyConfigurationFlagEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void ModifyGameInfoEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeGameInfo = new Mock<IGameInfo>();
+            var args = new ModifyGameInfoEventArgs(fakeCoreService.Object, fakeGameInfo.Object, fakeGameInfo.Object);
+            SnowflakeEventManager.EventSource.Subscribe<ModifyGameInfoEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void ModifyPlatformPreferenceEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakePlatformInfo = new Mock<IPlatformInfo>();
+            var args = new ModifyPlatformPreferenceEventArgs(fakeCoreService.Object, "test", "test", fakePlatformInfo.Object, PreferenceType.PREF_EMULATOR);
+            SnowflakeEventManager.EventSource.Subscribe<ModifyPlatformPreferenceEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void ModifyPortInputDeviceEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakePlatformInfo = new Mock<IPlatformInfo>();
+            var args = new ModifyPortInputDeviceEventArgs(fakeCoreService.Object, 1, fakePlatformInfo.Object, Snowflake.Controller.InputDeviceNames.KeyboardDevice, Snowflake.Controller.InputDeviceNames.KeyboardDevice);
+            SnowflakeEventManager.EventSource.Subscribe<ModifyPortInputDeviceEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void CoreLoadedEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var args = new CoreLoadedEventArgs(fakeCoreService.Object);
+            SnowflakeEventManager.EventSource.Subscribe<CoreLoadedEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void CoreShutdownEvent_Test()
+
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var args = new CoreShutdownEventArgs(fakeCoreService.Object);
+            SnowflakeEventManager.EventSource.Subscribe<CoreShutdownEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void AjaxRequestReceivedEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeJsRequest = new Mock<IJSRequest>();
+            var args = new AjaxRequestReceivedEventArgs(fakeCoreService.Object, fakeJsRequest.Object);
+            SnowflakeEventManager.EventSource.Subscribe<AjaxRequestReceivedEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+        [Fact]
+        public void AjaxResponseSendingEvent_Test()
+        {
+            SnowflakeEventManager.InitEventSource();
+            new StandardEvents().RegisterSnowflakeEvents(SnowflakeEventManager.EventSource);
+            var fakeCoreService = new Mock<ICoreService>();
+            var fakeJsResponse = new Mock<IJSResponse>();
+            var args = new AjaxResponseSendingEventArgs(fakeCoreService.Object, fakeJsResponse.Object);
+            SnowflakeEventManager.EventSource.Subscribe<AjaxResponseSendingEventArgs>((s, e) =>
+            {
+                Assert.Equal(args, e);
+            });
+            SnowflakeEventManager.EventSource.RaiseEvent(args);
+        }
+
+    }
+
+}

--- a/Snowflake.Tests/Snowflake.Tests.csproj
+++ b/Snowflake.Tests/Snowflake.Tests.csproj
@@ -103,7 +103,7 @@
     <Compile Include="Controller\GamepadAbstractionDatabaseTests.cs" />
     <Compile Include="Emulator\ConfigurationFlagStoreTests.cs" />
     <Compile Include="Events\SnowflakeEventManagerTests.cs" />
-    <Compile Include="Events\SnowflakeEventSourceTest.cs" />
+    <Compile Include="Events\StandardEventsTests.cs" />
     <Compile Include="Game\GameDatabaseTests.cs" />
     <Compile Include="Game\GameInfoTests.cs" />
     <Compile Include="Game\GameMediaCacheTests.cs" />

--- a/Snowflake.Tests/Snowflake.Tests.csproj
+++ b/Snowflake.Tests/Snowflake.Tests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Controller\GamepadAbstractionDatabaseTests.cs" />
     <Compile Include="Emulator\ConfigurationFlagStoreTests.cs" />
     <Compile Include="Events\SnowflakeEventManagerTests.cs" />
+    <Compile Include="Events\SnowflakeEventSourceTest.cs" />
     <Compile Include="Game\GameDatabaseTests.cs" />
     <Compile Include="Game\GameInfoTests.cs" />
     <Compile Include="Game\GameMediaCacheTests.cs" />


### PR DESCRIPTION
This PR renames SnowflakeEventSource to StandardEvents for clarity and re-adds tests for StandardEvents.