### PR TITLE
[BREAKING] IKeyboardMapping: Add mouse support to mappingData Fixes (#136)

### DIFF
--- a/Snowflake.API/Emulator/Input/IKeyboardMapping.cs
+++ b/Snowflake.API/Emulator/Input/IKeyboardMapping.cs
@@ -101,6 +101,10 @@ namespace Snowflake.Emulator.Input
         string KEY_X { get; }
         string KEY_Y { get; }
         string KEY_Z { get; }
+        string MOUSE_Y_DOWN { get; }
+        string MOUSE_Y_UP { get; }
+        string MOUSE_X_LEFT { get; }
+        string MOUSE_X_RIGHT { get; }
         string this[string key] { get; }
     }
 }

--- a/Snowflake/Emulator/Input/KeyboardMapping.cs
+++ b/Snowflake/Emulator/Input/KeyboardMapping.cs
@@ -102,6 +102,10 @@ namespace Snowflake.Emulator.Input
         public string KEY_F_10 { get; private set; }
         public string KEY_F_11 { get; private set; }
         public string KEY_F_12 { get; private set; }
+        public string MOUSE_Y_DOWN { get; private set; }
+        public string MOUSE_Y_UP { get; private set; }
+        public string MOUSE_X_LEFT { get; private set; }
+        public string MOUSE_X_RIGHT { get; private set; }
         private IDictionary<string, string> mappingData;
 
         public KeyboardMapping(IDictionary<string, string> mappingData)
@@ -201,6 +205,10 @@ namespace Snowflake.Emulator.Input
             this.KEY_F_10 = mappingData["KEY_F_10"];
             this.KEY_F_11 = mappingData["KEY_F_11"];
             this.KEY_F_12 = mappingData["KEY_F_12"];
+            this.MOUSE_Y_DOWN = mappingData["MOUSE_Y_DOWN"];
+            this.MOUSE_Y_UP = mappingData["MOUSE_Y_UP"];
+            this.MOUSE_X_LEFT = mappingData["MOUSE_X_LEFT"];
+            this.MOUSE_X_RIGHT = mappingData["MOUSE_X_RIGHT"];
         }
 
         public string this[string key]

--- a/Snowflake/Emulator/Input/KeyboardMapping.cs
+++ b/Snowflake/Emulator/Input/KeyboardMapping.cs
@@ -106,6 +106,12 @@ namespace Snowflake.Emulator.Input
         public string MOUSE_Y_UP { get; private set; }
         public string MOUSE_X_LEFT { get; private set; }
         public string MOUSE_X_RIGHT { get; private set; }
+        public string MOUSE_LCLICK { get; private set; }
+        public string MOUSE_RCLICK { get; private set; }
+        public string MOUSE_MCLICK { get; private set; }
+        public string MOUSE_WHEELUP { get; private set; }
+        public string MOUSE_WHEELDOWN { get; private set; }
+
         private IDictionary<string, string> mappingData;
 
         public KeyboardMapping(IDictionary<string, string> mappingData)
@@ -209,6 +215,11 @@ namespace Snowflake.Emulator.Input
             this.MOUSE_Y_UP = mappingData["MOUSE_Y_UP"];
             this.MOUSE_X_LEFT = mappingData["MOUSE_X_LEFT"];
             this.MOUSE_X_RIGHT = mappingData["MOUSE_X_RIGHT"];
+            this.MOUSE_LCLICK = mappingData["MOUSE_LCLICK"];
+            this.MOUSE_RCLICK = mappingData["MOUSE_RCLICK"];
+            this.MOUSE_MCLICK = mappingData["MOUSE_MCLICK"];
+            this.MOUSE_WHEELUP = mappingData["MOUSE_WHEELUP"];
+            this.MOUSE_WHEELDOWN = mappingData["MOUSE_WHEELDOWN"];
         }
 
         public string this[string key]


### PR DESCRIPTION
This breaks compatibility with EmulatorBridge plugins that now must accommodate for the new IKeyboardMapping keys

- MOUSE_X_LEFT
- MOUSE_X_RIGHT
- MOUSE_Y_UP
- MOUSE_Y_DOWN

Todo
------
- [x] MOUSE_LCLICK
- [x] MOUSE_RCLICK
- [x] MOUSE_MCLICK
- [x] MOUSE_WHEELUP
- [x] MOUSE_WHEELDOWN