### PR TITLE
EmulatorAssembly: Use JSON rather than YAML emulator files

### DIFF
--- a/Snowflake.Service/Service/Manager/EmulatorAssembliesManager.cs
+++ b/Snowflake.Service/Service/Manager/EmulatorAssembliesManager.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Snowflake.Extensions;
 using Snowflake.Emulator;
 using System.IO;
-using SharpYaml.Serialization;
+using Newtonsoft.Json;
 
 namespace Snowflake.Service.Manager
 {
@@ -26,7 +26,7 @@ namespace Snowflake.Service.Manager
             if (!Directory.Exists(this.AssembliesLocation)) Directory.CreateDirectory(this.AssembliesLocation);
             foreach (string fileName in Directory.GetFiles(this.AssembliesLocation))
             {
-                if (!(Path.GetExtension(fileName) == ".yml")) continue;
+                if (!(Path.GetExtension(fileName) == ".emulatordef")) continue;
                 
                 var emulatorCore = EmulatorAssembliesManager.ParseEmulatorAssembly(fileName);
                 this.emulatorAssemblies.Add(emulatorCore.EmulatorID, emulatorCore);
@@ -37,7 +37,7 @@ namespace Snowflake.Service.Manager
         }
         public static IEmulatorAssembly ParseEmulatorAssembly(string emulatorCorePath)
         {
-            var emulator = new Serializer().Deserialize<Dictionary<string, dynamic>>(File.ReadAllText(emulatorCorePath));
+            var emulator = JsonConvert.DeserializeObject<IDictionary<string, string>>(File.ReadAllText(emulatorCorePath));
             return EmulatorAssembly.FromJsonProtoTemplate(emulator);
         }
 

--- a/Snowflake/Emulator/EmulatorAssembly.cs
+++ b/Snowflake/Emulator/EmulatorAssembly.cs
@@ -32,7 +32,7 @@ namespace Snowflake.Emulator
             this.AssemblyType = assemblyType;
         }
 
-        public static EmulatorAssembly FromJsonProtoTemplate (IDictionary<string, dynamic> emulatorAssembly){
+        public static EmulatorAssembly FromJsonProtoTemplate (IDictionary<string, string> emulatorAssembly){
             return new EmulatorAssembly(emulatorAssembly["main"], emulatorAssembly["id"], emulatorAssembly["name"], emulatorAssembly["type"]);
         }
     }


### PR DESCRIPTION
This removes the final required dependency on SharpYaml except for YamlConfiguration.
The schema is the same, however the filename shall be .emulatordef and be in JSON.