### PR TITLE
BREAKING IEmulatorBridge: Pass IGameInfo for the game when compiling controller config

### DIFF
--- a/Snowflake.API/Emulator/IEmulatorBridge.cs
+++ b/Snowflake.API/Emulator/IEmulatorBridge.cs
@@ -54,24 +54,25 @@ namespace Snowflake.Emulator
         /// </summary>
         /// <param name="configurationProfile">The configuration profile to compile</param>
         /// <returns>The compiled configuration</returns>
-        string CompileConfiguration(IConfigurationProfile configurationProfile);
+        string CompileConfiguration(IConfigurationProfile configurationProfile, IGameInfo gameInfo);
         /// <summary>
         /// Compile configuration
         /// </summary>
         /// <param name="configurationTemplate">The configuration template for the profile</param>
         /// <param name="configurationProfile">The configuration profile to compile</param>
         /// <returns></returns>
-        string CompileConfiguration(IConfigurationTemplate configurationTemplate, IConfigurationProfile configurationProfile);
+        
+        string CompileConfiguration(IConfigurationTemplate configurationTemplate, IConfigurationProfile configurationProfile, IGameInfo game);
         /// <summary>
         /// Compile the controller for a specified player index
         /// </summary>
         /// <param name="playerIndex">The player index to compile for</param>
         /// <param name="controllerDefinition">The controller definition to compile for</param>
         /// <param name="controllerTemplate">The controller template to compile for</param>
-        /// <param name="controllerProfile">The controller profile to compile for</param>
         /// <param name="inputTemplate">The input template to compile for</param>
         /// <returns></returns>
-        string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate);
+        /// 
+        string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IGameInfo game);
         /// <summary>
         /// Compile a controller given a specific platform
         /// </summary>
@@ -79,8 +80,20 @@ namespace Snowflake.Emulator
         /// <param name="platformInfo">The platform to compile for</param>
         /// <param name="inputTemplate">The input template to compile for</param>
         /// <returns></returns>
-        string CompileController(int playerIndex, IPlatformInfo platformInfo, IInputTemplate inputTemplate);
-        string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IReadOnlyDictionary<string, IControllerMapping> controllerMappings);
+        string CompileController(int playerIndex, IPlatformInfo platformInfo, IInputTemplate inputTemplate, IGameInfo game);
+
+        /// <summary>
+        /// Compile Controller given all available information
+        /// </summary>
+        /// <param name="playerIndex">The player index to compile for</param>
+        /// <param name="platformInfo">The platform to compile for</param>
+        /// <param name="inputTemplate">The input template to compile for</param>
+        /// <param name="controllerDefinition"></param>
+        /// <param name="controllerTemplate"></param>
+        /// <param name="gamepadAbstraction"></param>
+        /// <param name="controllerMappings"></param>
+        /// <returns></returns>
+        string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IReadOnlyDictionary<string, IControllerMapping> controllerMappings, IGameInfo game);
 
         /// <summary>
         /// Shutdownt the currently running emulator

--- a/Snowflake/Emulator/EmulatorBridge.cs
+++ b/Snowflake/Emulator/EmulatorBridge.cs
@@ -44,11 +44,11 @@ namespace Snowflake.Emulator
         public abstract void StartRom(IGameInfo gameInfo);
         public abstract void HandlePrompt(string messagge);
         public abstract void ShutdownEmulator();
-        public virtual string CompileConfiguration(IConfigurationProfile configProfile)
+        public virtual string CompileConfiguration(IConfigurationProfile configProfile, IGameInfo gameInfo)
         {
-            return this.CompileConfiguration(this.ConfigurationTemplates[configProfile.TemplateID], configProfile);
+            return this.CompileConfiguration(this.ConfigurationTemplates[configProfile.TemplateID], configProfile, gameInfo);
         }
-        public virtual string CompileConfiguration(IConfigurationTemplate configTemplate, IConfigurationProfile configProfile)
+        public virtual string CompileConfiguration(IConfigurationTemplate configTemplate, IConfigurationProfile configProfile, IGameInfo gameInfo)
         {
             var template = new StringBuilder(configTemplate.StringTemplate);
             foreach (var configurationValue in configProfile.ConfigurationValues)
@@ -67,7 +67,7 @@ namespace Snowflake.Emulator
             }
             return template.ToString();
         }
-        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IInputTemplate inputTemplate)
+        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IInputTemplate inputTemplate, IGameInfo gameInfo)
         {
             string deviceName = this.CoreInstance.ControllerPortsDatabase.GetDeviceInPort(platformInfo, playerIndex);
             string controllerId = platformInfo.ControllerPorts[playerIndex];
@@ -78,18 +78,19 @@ namespace Snowflake.Emulator
                 controllerDefinition,
                 this.ControllerTemplates[controllerId],
                 gamepadAbstraction,
-                inputTemplate);
+                inputTemplate,
+                gameInfo);
         }
 
-        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate)
+        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IGameInfo gameInfo)
         {
             if (gamepadAbstraction.ProfileType == ControllerProfileType.NULL_PROFILE) return String.Empty;
             var controllerMappings = gamepadAbstraction.ProfileType == ControllerProfileType.KEYBOARD_PROFILE ?
                 controllerTemplate.KeyboardControllerMappings : controllerTemplate.GamepadControllerMappings;
-            return this.CompileController(playerIndex, platformInfo, controllerDefinition, controllerTemplate, gamepadAbstraction, inputTemplate, controllerMappings);
+            return this.CompileController(playerIndex, platformInfo, controllerDefinition, controllerTemplate, gamepadAbstraction, inputTemplate, controllerMappings, gameInfo);
         }
 
-        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IReadOnlyDictionary<string, IControllerMapping> controllerMappings)
+        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IReadOnlyDictionary<string, IControllerMapping> controllerMappings, IGameInfo gameInfo)
         {
             if (gamepadAbstraction.ProfileType == ControllerProfileType.NULL_PROFILE) return String.Empty;
             var template = new StringBuilder(inputTemplate.StringTemplate);


### PR DESCRIPTION
**This is an API level break; all emulator bridge plugins that override the default CompileConfiguration methods will require small changes before it builds again**

This was a giant oversight in the original design of the CompileConfiguration API; the IGameInfo object is never passed to the method, so the API is not aware of which game it is compiling configuration for. While this may be redundant, without this, there is no way to do flag-aware controller compilation, such as required for Dolphin's Wiimote attachments. Most emulator bridges will never need to be aware of the IGameInfo object it's called with, but for those that do, the IGameInfo object is now passed through every single overload to ensure all bridges will have access to this info no matter how far up the chain they are overloading.