### PR TITLE
[WIP BREAKING] Instance-based emulator bridges (Fixes #188)

### DIFF
--- a/Snowflake.API/Emulator/EmulatorInstanceState.cs
+++ b/Snowflake.API/Emulator/EmulatorInstanceState.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Snowflake.Emulator
+{
+    /// <summary>
+    /// Represents the state of an instance.
+    /// </summary>
+    public enum EmulatorInstanceState
+    {
+        /// <summary>
+        /// A game is running in this instance.
+        /// </summary>
+        GameRunning,
+        /// <summary>
+        /// A game is paused in this instance.
+        /// </summary>
+        GamePaused,
+        /// <summary>
+        /// The instance has been shutdown.
+        /// </summary>
+        InstanceShutdown,
+        /// <summary>
+        /// The instance has yet to be started.
+        /// </summary>
+        InstanceNotStarted,
+        /// <summary>
+        /// The instance is initiating startup.
+        /// </summary>
+        InstanceInitiating,
+        /// <summary>
+        /// The instance is inactive (paused and minimized).
+        /// </summary>
+        InstanceInactive,
+        /// <summary>
+        /// The instance is closed and can not be restarted
+        /// </summary>
+        InstanceClosed,
+        /// <summary>
+        /// The instance encountered an error
+        /// </summary>
+        InstanceError
+
+    }
+}

--- a/Snowflake.API/Emulator/IEmulatorBridge.cs
+++ b/Snowflake.API/Emulator/IEmulatorBridge.cs
@@ -44,24 +44,25 @@ namespace Snowflake.Emulator
         /// </summary>
         IConfigurationFlagStore ConfigurationFlagStore { get; }
         /// <summary>
-        /// Creates and prepares an emulator instance to get ready to start the game.
+        /// Prepares an emulator instance to get ready to start the game.
         /// </summary>
         /// <param name="gameInfo">The game to start</param>
-        IEmulatorInstance CreateInstance(IGameInfo gameInfo);
+        IEmulatorInstance SetupInstance(IGameInfo gameInfo);
         /// <summary>
         /// Compile configuration
         /// </summary>
         /// <param name="configurationProfile">The configuration profile to compile</param>
         /// <returns>The compiled configuration</returns>
-        string CompileConfiguration(IConfigurationProfile configurationProfile, IGameInfo gameInfo);
+        string CompileConfiguration(IConfigurationProfile configurationProfile, IEmulatorInstance instance);
+
         /// <summary>
         /// Compile configuration
         /// </summary>
         /// <param name="configurationTemplate">The configuration template for the profile</param>
         /// <param name="configurationProfile">The configuration profile to compile</param>
-        /// <returns></returns>
-        
-        string CompileConfiguration(IConfigurationTemplate configurationTemplate, IConfigurationProfile configurationProfile, IGameInfo game);
+        /// <param name="instance">The instance this compiliation is for</param>
+        /// <returns>The compiled configuration</returns>
+        string CompileConfiguration(IConfigurationTemplate configurationTemplate, IConfigurationProfile configurationProfile, IEmulatorInstance instance);
         /// <summary>
         /// Compile the controller for a specified player index
         /// </summary>
@@ -69,17 +70,18 @@ namespace Snowflake.Emulator
         /// <param name="controllerDefinition">The controller definition to compile for</param>
         /// <param name="controllerTemplate">The controller template to compile for</param>
         /// <param name="inputTemplate">The input template to compile for</param>
-        /// <returns></returns>
-        /// 
-        string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IGameInfo game);
+        /// <param name="instance">The instance this compiliation is for</param>
+        /// <returns>The compiled controller configuration</returns>
+        string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IEmulatorInstance instance);
         /// <summary>
         /// Compile a controller given a specific platform
         /// </summary>
         /// <param name="playerIndex">The player index to compile for</param>
         /// <param name="platformInfo">The platform to compile for</param>
         /// <param name="inputTemplate">The input template to compile for</param>
-        /// <returns></returns>
-        string CompileController(int playerIndex, IPlatformInfo platformInfo, IInputTemplate inputTemplate, IGameInfo game);
+        /// <param name="instance">The instance this compiliation is for</param>=
+        /// <returns>The compiled controller configuration</returns>
+        string CompileController(int playerIndex, IPlatformInfo platformInfo, IInputTemplate inputTemplate, IEmulatorInstance instance);
 
         /// <summary>
         /// Compile Controller given all available information
@@ -87,12 +89,14 @@ namespace Snowflake.Emulator
         /// <param name="playerIndex">The player index to compile for</param>
         /// <param name="platformInfo">The platform to compile for</param>
         /// <param name="inputTemplate">The input template to compile for</param>
-        /// <param name="controllerDefinition"></param>
-        /// <param name="controllerTemplate"></param>
-        /// <param name="gamepadAbstraction"></param>
-        /// <param name="controllerMappings"></param>
-        /// <returns></returns>
-        string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IReadOnlyDictionary<string, IControllerMapping> controllerMappings, IGameInfo game);
+        /// <param name="controllerDefinition">The controller definition to compile for</param>
+        /// <param name="controllerTemplate">The controller template</param>
+        /// <param name="gamepadAbstraction">The gamepad abstraction used</param>
+        /// <param name="controllerMappings">The controller mappings used</param>
+        /// <param name="instance">The instance this compiliation is for</param>
+        /// <returns>The compiled controller configuration</returns>
+
+        string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IReadOnlyDictionary<string, IControllerMapping> controllerMappings, IEmulatorInstance instance);
   
     }
 }

--- a/Snowflake.API/Emulator/IEmulatorBridge.cs
+++ b/Snowflake.API/Emulator/IEmulatorBridge.cs
@@ -44,10 +44,10 @@ namespace Snowflake.Emulator
         /// </summary>
         IConfigurationFlagStore ConfigurationFlagStore { get; }
         /// <summary>
-        /// Start a game rom
+        /// Creates and prepares an emulator instance to get ready to start the game.
         /// </summary>
         /// <param name="gameInfo">The game to start</param>
-        void StartRom(IGameInfo gameInfo);
+        IEmulatorInstance CreateInstance(IGameInfo gameInfo);
         /// <summary>
         /// Compile configuration
         /// </summary>
@@ -93,16 +93,6 @@ namespace Snowflake.Emulator
         /// <param name="controllerMappings"></param>
         /// <returns></returns>
         string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IReadOnlyDictionary<string, IControllerMapping> controllerMappings, IGameInfo game);
-
-        /// <summary>
-        /// Shutdownt the currently running emulator
-        /// </summary>
-        void ShutdownEmulator();
-        /// <summary>
-        /// Handle a message sent to the emulator bridge 
-        /// </summary>
-        /// <param name="promptMessage">The message sent to the emulator</param>
-        void HandlePrompt(string promptMessage);
-       
+  
     }
 }

--- a/Snowflake.API/Emulator/IEmulatorInstance.cs
+++ b/Snowflake.API/Emulator/IEmulatorInstance.cs
@@ -46,7 +46,7 @@ namespace Snowflake.Emulator
         /// <returns>The resultant state of the action</returns>
         EmulatorInstanceState ShutdownGame();
         /// <summary>
-        /// Cleansup the instance.
+        /// Closes and cleans up the instance.
         /// </summary>
         /// <returns>The resultant state of the action</returns>
         EmulatorInstanceState CleanupInstance();
@@ -55,6 +55,10 @@ namespace Snowflake.Emulator
         /// </summary>
         /// <returns>The resultant state of the action</returns>
         EmulatorInstanceState SendCustomMessage(string message, out string response);
+        /// <summary>
+        /// A unique identifier of the instance
+        /// </summary>
+        string InstanceId { get; }
 
     }
 }

--- a/Snowflake.API/Emulator/IEmulatorInstance.cs
+++ b/Snowflake.API/Emulator/IEmulatorInstance.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Snowflake.Game;
+
+namespace Snowflake.Emulator
+{
+    /// <summary>
+    /// Represents an instance of an emulator. This can be an external process or a called DLL. 
+    /// This object is usually created by a bridge plugin. Setup of the instance is the responsibiltity of the bridge plugin.
+    /// </summary>
+    public interface IEmulatorInstance
+    {
+
+        /// <summary>
+        /// The current state of the instance
+        /// </summary>
+        EmulatorInstanceState InstanceState { get; }
+        /// <summary>
+        /// The game this instance is associated with.
+        /// </summary>
+        IGameInfo InstanceGame { get; }
+        /// <summary>
+        /// A temporary directory created for this instance. This directory should be deleted if the state ever reaches "InstanceClosed"
+        /// </summary>
+        string InstanceTemporaryDirectory { get; }
+        /// <summary>
+        /// The emulator bridge this instance is associated with.
+        /// </summary>
+        IEmulatorBridge InstanceEmulator { get; }
+        /// <summary>
+        /// Start the game assigned to this instance
+        /// </summary>
+        /// <returns>The resultant state of the action</returns>
+        EmulatorInstanceState StartGame();
+        /// <summary>
+        /// Pause the game currently running in the instance
+        /// </summary>
+        /// <returns>The resultant state of the action</returns>
+        EmulatorInstanceState PauseGame();
+        /// <summary>
+        /// Shutdown the game currently running in the instance
+        /// </summary>
+        /// <returns>The resultant state of the action</returns>
+        EmulatorInstanceState ShutdownGame();
+        /// <summary>
+        /// Cleansup the instance.
+        /// </summary>
+        /// <returns>The resultant state of the action</returns>
+        EmulatorInstanceState CleanupInstance();
+        /// <summary>
+        /// This method can be overridden by plugins to handle sending custom messages, and optionally receive a response
+        /// </summary>
+        /// <returns>The resultant state of the action</returns>
+        EmulatorInstanceState SendCustomMessage(string message, out string response);
+
+    }
+}

--- a/Snowflake.API/Service/Manager/IEmulatorBridgeManager.cs
+++ b/Snowflake.API/Service/Manager/IEmulatorBridgeManager.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Snowflake.Emulator;
+
+namespace Snowflake.Service.Manager
+{
+    public interface IEmulatorBridgeManager : IDisposable
+    {
+        /// <summary>
+        /// Adds an instance to the container, and returns a unique ID for the instance
+        /// </summary>
+        void AddInstance(IEmulatorInstance instance);
+        /// <summary>
+        /// Removes an instance from the container;
+        /// </summary>
+        /// <param name="instance"></param>
+        void RemoveInstance(IEmulatorInstance instance);
+        /// <summary>
+        /// Gets an instance given it's instance ID
+        /// </summary>
+        /// <param name="instanceId"></param>
+        void GetInstance(string instanceId);
+        /// <summary>
+        /// Gets all instances that belong to a certain emulator
+        /// </summary>
+        /// <param name="bridge">The emulator bridge to get</param>
+        void GetInstances(IEmulatorBridge bridge);
+        /// <summary>
+        /// Get instances of a certain state.
+        /// </summary>
+        /// <param name="state">The state of the instances</param>
+        void GetInstances(EmulatorInstanceState state);
+        /// <summary>
+        /// Shuts down every single instance in the container, and purges the container.
+        /// </summary>
+        void ShutdownInstances();
+        /// <summary>
+        /// Removes hanging instances (ones that have shut down) from the container
+        /// </summary>
+        void PurgeHangingInstances();
+        /// <summary>
+        /// Disposes the container, shutting down all hanging instances.
+        /// </summary>
+        void Dispose();
+    }
+}

--- a/Snowflake.API/Service/Manager/IEmulatorInstanceManager.cs
+++ b/Snowflake.API/Service/Manager/IEmulatorInstanceManager.cs
@@ -10,10 +10,9 @@ namespace Snowflake.Service.Manager
     public interface IEmulatorInstanceManager : IDisposable
     {
         /// <summary>
-        /// Adds an instance to the container, and returns the instance.
-        /// <returns>The instance that was added.</returns>
+        /// Adds an instance to the container.
         /// </summary>
-        IEmulatorInstance AddInstance(IEmulatorInstance instance);
+        void AddInstance(IEmulatorInstance instance);
         /// <summary>
         /// Removes an instance from the container;
         /// </summary>
@@ -23,21 +22,21 @@ namespace Snowflake.Service.Manager
         /// Gets an instance given it's instance ID
         /// </summary>
         /// <param name="instanceId"></param>
-        void GetInstance(string instanceId);
+        IEmulatorInstance GetInstance(string instanceId);
         /// <summary>
         /// Gets all instances that belong to a certain emulator
         /// </summary>
         /// <param name="bridge">The emulator bridge to get</param>
-        void GetInstances(IEmulatorBridge bridge);
+        IEnumerable<IEmulatorInstance> GetInstances(IEmulatorBridge bridge);
         /// <summary>
         /// Get instances of a certain state.
         /// </summary>
         /// <param name="state">The state of the instances</param>
-        void GetInstances(EmulatorInstanceState state);
+        IEnumerable<IEmulatorInstance> GetInstances(EmulatorInstanceState state);
         /// <summary>
-        /// Shuts down every single instance in the container, and purges the container.
+        /// Closes every single instance in the container, and purges the container.
         /// </summary>
-        void ShutdownInstances();
+        void CloseInstances();
         /// <summary>
         /// Removes hanging instances (ones that have shut down) from the container
         /// </summary>
@@ -45,6 +44,6 @@ namespace Snowflake.Service.Manager
         /// <summary>
         /// Disposes the container, shutting down all hanging instances.
         /// </summary>
-        void Dispose();
+        new void Dispose();
     }
 }

--- a/Snowflake.API/Service/Manager/IEmulatorInstanceManager.cs
+++ b/Snowflake.API/Service/Manager/IEmulatorInstanceManager.cs
@@ -7,12 +7,13 @@ using Snowflake.Emulator;
 
 namespace Snowflake.Service.Manager
 {
-    public interface IEmulatorBridgeManager : IDisposable
+    public interface IEmulatorInstanceManager : IDisposable
     {
         /// <summary>
-        /// Adds an instance to the container, and returns a unique ID for the instance
+        /// Adds an instance to the container, and returns the instance.
+        /// <returns>The instance that was added.</returns>
         /// </summary>
-        void AddInstance(IEmulatorInstance instance);
+        IEmulatorInstance AddInstance(IEmulatorInstance instance);
         /// <summary>
         /// Removes an instance from the container;
         /// </summary>

--- a/Snowflake.API/Snowflake.API.csproj
+++ b/Snowflake.API/Snowflake.API.csproj
@@ -90,6 +90,8 @@
     <Compile Include="Ajax\IJSResponse.cs" />
     <Compile Include="Controller\IGamepadAbstraction.cs" />
     <Compile Include="Controller\IGamepadAbstractionDatabase.cs" />
+    <Compile Include="Emulator\EmulatorInstanceState.cs" />
+    <Compile Include="Emulator\IEmulatorInstance.cs" />
     <Compile Include="Emulator\Input\InputManager\InputDeviceNames.cs" />
     <Compile Include="Emulator\Configuration\IConfigurationFlagSelectValue.cs" />
     <Compile Include="Emulator\Configuration\IConfigurationFlagStore.cs" />
@@ -117,6 +119,7 @@
     <Compile Include="Emulator\Input\Constants\KeyboardConstants.cs" />
     <Compile Include="Game\GameInfoFields.cs" />
     <Compile Include="Plugin\PluginInfoFields.cs" />
+    <Compile Include="Service\Manager\IEmulatorInstanceManager.cs" />
     <Compile Include="Service\IScrapeEngine.cs" />
     <Compile Include="Scraper\ScraperInfoFields.cs" />
     <Compile Include="Emulator\Configuration\IBooleanMapping.cs" />

--- a/Snowflake.Service/Service/Manager/EmulatorInstanceManager.cs
+++ b/Snowflake.Service/Service/Manager/EmulatorInstanceManager.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Snowflake.Emulator;
+
+namespace Snowflake.Service.Manager
+{
+    public class EmulatorInstanceManager : IEmulatorInstanceManager
+    {
+        private readonly ICoreService coreService;
+        private readonly IList<IEmulatorInstance> emulatorInstances;
+        public EmulatorInstanceManager(ICoreService coreService)
+        {
+            this.coreService = coreService;
+            this.emulatorInstances = new List<IEmulatorInstance>();
+        }
+        public void AddInstance(IEmulatorInstance instance)
+        {
+            this.emulatorInstances.Add(instance);
+        }
+
+        public void RemoveInstance(IEmulatorInstance instance)
+        {
+            this.emulatorInstances.Remove(instance);
+        }
+
+        public IEmulatorInstance GetInstance(string instanceId)
+        {
+            return this.emulatorInstances.First(i => i.InstanceId == instanceId);
+        }
+
+        public IEnumerable<IEmulatorInstance> GetInstances(IEmulatorBridge bridge)
+        {
+            return this.emulatorInstances.Where(i => i.InstanceEmulator == bridge);
+        }
+
+        public IEnumerable<IEmulatorInstance> GetInstances(EmulatorInstanceState state)
+        {
+            return this.emulatorInstances.Where(i => i.InstanceState == state);
+        }
+
+        public void CloseInstances()
+        {
+            foreach (var instance in this.emulatorInstances)
+            {
+                instance.CleanupInstance();
+            }
+        }
+
+        public void PurgeHangingInstances()
+        {
+            foreach(var instance in this.emulatorInstances.Where(i => i.InstanceState == EmulatorInstanceState.InstanceClosed))
+            {
+                this.emulatorInstances.Remove(instance);
+            }
+        }
+
+        public void Dispose()
+        {
+            this.PurgeHangingInstances();
+        }
+    }
+}

--- a/Snowflake.Service/Snowflake.Service.csproj
+++ b/Snowflake.Service/Snowflake.Service.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Service\CoreService.cs" />
     <Compile Include="Service\Manager\AjaxManager.cs" />
     <Compile Include="Service\Manager\EmulatorAssembliesManager.cs" />
+    <Compile Include="Service\Manager\EmulatorInstanceManager.cs" />
     <Compile Include="Service\Manager\PluginManager.cs" />
     <Compile Include="Service\Manager\ServerManager.cs" />
     <Compile Include="Service\ScrapeEngine.cs" />

--- a/Snowflake.StandardAjax/StandardAjax.Game.cs
+++ b/Snowflake.StandardAjax/StandardAjax.Game.cs
@@ -296,15 +296,16 @@ namespace Snowflake.StandardAjax
             if (!gameStartEvent.Cancel)
             {
                 var instance = gameStartEvent.GameEmulatorBridge.CreateInstance(gameStartEvent.GameInfo);
-                this.CoreInstance.Get<IEmulatorInstanceManager>().AddInstance(instance).StartGame();
-                }
+                this.CoreInstance.Get<IEmulatorInstanceManager>().AddInstance(instance);
+                instance.StartGame();
+            }
                 return new JSResponse(request, gameInfo);
         }
 
         [AjaxMethod(MethodPrefix = "Game")]
         public IJSResponse HaltRunningGames(IJSRequest request)
         {
-            this.CoreInstance.Get<IEmulatorInstanceManager>().ShutdownInstances();
+            this.CoreInstance.Get<IEmulatorInstanceManager>().CloseInstances();
             return new JSResponse(request, null);
         }
 

--- a/Snowflake.StandardAjax/StandardAjax.Game.cs
+++ b/Snowflake.StandardAjax/StandardAjax.Game.cs
@@ -295,7 +295,7 @@ namespace Snowflake.StandardAjax
             SnowflakeEventManager.EventSource.RaiseEvent(gameStartEvent);
             if (!gameStartEvent.Cancel)
             {
-                var instance = gameStartEvent.GameEmulatorBridge.CreateInstance(gameStartEvent.GameInfo);
+                var instance = gameStartEvent.GameEmulatorBridge.SetupInstance(gameStartEvent.GameInfo);
                 this.CoreInstance.Get<IEmulatorInstanceManager>().AddInstance(instance);
                 instance.StartGame();
             }

--- a/Snowflake.StandardAjax/StandardAjax.Game.cs
+++ b/Snowflake.StandardAjax/StandardAjax.Game.cs
@@ -295,18 +295,16 @@ namespace Snowflake.StandardAjax
             SnowflakeEventManager.EventSource.RaiseEvent(gameStartEvent);
             if (!gameStartEvent.Cancel)
             {
-                gameStartEvent.GameEmulatorBridge.CreateInstance(gameStartEvent.GameInfo);
-            }
-            return new JSResponse(request, gameInfo);
+                var instance = gameStartEvent.GameEmulatorBridge.CreateInstance(gameStartEvent.GameInfo);
+                this.CoreInstance.Get<IEmulatorInstanceManager>().AddInstance(instance).StartGame();
+                }
+                return new JSResponse(request, gameInfo);
         }
 
         [AjaxMethod(MethodPrefix = "Game")]
         public IJSResponse HaltRunningGames(IJSRequest request)
         {
-            foreach (IEmulatorBridge emulator in this.CoreInstance.Get<IPluginManager>().Plugins<IEmulatorBridge>().Values)
-            {
-                emulator.ShutdownEmulator();
-            }
+            this.CoreInstance.Get<IEmulatorInstanceManager>().ShutdownInstances();
             return new JSResponse(request, null);
         }
 

--- a/Snowflake.StandardAjax/StandardAjax.Game.cs
+++ b/Snowflake.StandardAjax/StandardAjax.Game.cs
@@ -295,7 +295,7 @@ namespace Snowflake.StandardAjax
             SnowflakeEventManager.EventSource.RaiseEvent(gameStartEvent);
             if (!gameStartEvent.Cancel)
             {
-                gameStartEvent.GameEmulatorBridge.StartRom(gameStartEvent.GameInfo);
+                gameStartEvent.GameEmulatorBridge.CreateInstance(gameStartEvent.GameInfo);
             }
             return new JSResponse(request, gameInfo);
         }

--- a/Snowflake/Emulator/EmulatorBridge.cs
+++ b/Snowflake/Emulator/EmulatorBridge.cs
@@ -38,7 +38,7 @@ namespace Snowflake.Emulator
             this.ConfigurationFlagStore = new ConfigurationFlagStore(this);
         }
 
-        public abstract void StartRom(IGameInfo gameInfo);
+        public abstract IEmulatorInstance CreateInstance(IGameInfo gameInfo);
         public abstract void HandlePrompt(string messagge);
         public abstract void ShutdownEmulator();
         public virtual string CompileConfiguration(IConfigurationProfile configProfile, IGameInfo gameInfo)

--- a/Snowflake/Emulator/EmulatorBridge.cs
+++ b/Snowflake/Emulator/EmulatorBridge.cs
@@ -38,14 +38,14 @@ namespace Snowflake.Emulator
             this.ConfigurationFlagStore = new ConfigurationFlagStore(this);
         }
 
-        public abstract IEmulatorInstance CreateInstance(IGameInfo gameInfo);
+        public abstract IEmulatorInstance SetupInstance(IGameInfo gameInfo);
         public abstract void HandlePrompt(string messagge);
         public abstract void ShutdownEmulator();
-        public virtual string CompileConfiguration(IConfigurationProfile configProfile, IGameInfo gameInfo)
+        public virtual string CompileConfiguration(IConfigurationProfile configProfile, IEmulatorInstance instance)
         {
-            return this.CompileConfiguration(this.ConfigurationTemplates[configProfile.TemplateID], configProfile, gameInfo);
+            return this.CompileConfiguration(this.ConfigurationTemplates[configProfile.TemplateID], configProfile, instance);
         }
-        public virtual string CompileConfiguration(IConfigurationTemplate configTemplate, IConfigurationProfile configProfile, IGameInfo gameInfo)
+        public virtual string CompileConfiguration(IConfigurationTemplate configTemplate, IConfigurationProfile configProfile, IEmulatorInstance instance)
         {
             var template = new StringBuilder(configTemplate.StringTemplate);
             foreach (var configurationValue in configProfile.ConfigurationValues)
@@ -56,7 +56,7 @@ namespace Snowflake.Emulator
             }
             return template.ToString();
         }
-        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IInputTemplate inputTemplate, IGameInfo gameInfo)
+        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IInputTemplate inputTemplate, IEmulatorInstance instance)
         {
             string deviceName = this.CoreInstance.Get<IControllerPortsDatabase>().GetDeviceInPort(platformInfo, playerIndex);
             string controllerId = platformInfo.ControllerPorts[playerIndex];
@@ -68,18 +68,18 @@ namespace Snowflake.Emulator
                 this.ControllerTemplates[controllerId],
                 gamepadAbstraction,
                 inputTemplate,
-                gameInfo);
+                instance);
         }
 
-        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IGameInfo gameInfo)
+        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IEmulatorInstance instance)
         {
             if (gamepadAbstraction.ProfileType == ControllerProfileType.NULL_PROFILE) return string.Empty;
             var controllerMappings = gamepadAbstraction.ProfileType == ControllerProfileType.KEYBOARD_PROFILE ?
                 controllerTemplate.KeyboardControllerMappings : controllerTemplate.GamepadControllerMappings;
-            return this.CompileController(playerIndex, platformInfo, controllerDefinition, controllerTemplate, gamepadAbstraction, inputTemplate, controllerMappings, gameInfo);
+            return this.CompileController(playerIndex, platformInfo, controllerDefinition, controllerTemplate, gamepadAbstraction, inputTemplate, controllerMappings, instance);
         }
 
-        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IReadOnlyDictionary<string, IControllerMapping> controllerMappings, IGameInfo gameInfo)
+        public virtual string CompileController(int playerIndex, IPlatformInfo platformInfo, IControllerDefinition controllerDefinition, IControllerTemplate controllerTemplate, IGamepadAbstraction gamepadAbstraction, IInputTemplate inputTemplate, IReadOnlyDictionary<string, IControllerMapping> controllerMappings, IEmulatorInstance instance)
         {
             if (gamepadAbstraction.ProfileType == ControllerProfileType.NULL_PROFILE) return string.Empty;
             var template = new StringBuilder(inputTemplate.StringTemplate);
@@ -92,17 +92,13 @@ namespace Snowflake.Emulator
                 template.Replace($"{{{templateKey}}}", emulatorValue);
             }
 
-            foreach (var key in inputTemplate.TemplateKeys)
+            foreach (string key in inputTemplate.TemplateKeys)
             {
                 template.Replace("{N}", playerIndex.ToString()); //Player Index
-                if (controllerMappings["default"].KeyMappings.ContainsKey(key))
-                {
-                    template.Replace($"{{{key}}}", controllerMappings["default"].KeyMappings[key]); //Non-input keys
-                }
-                else
-                {
-                    template.Replace($"{{{key}}}", inputTemplate.NoBind); //Non-input keys
-                }
+                template.Replace($"{{{key}}}",
+                    controllerMappings["default"].KeyMappings.ContainsKey(key)
+                        ? controllerMappings["default"].KeyMappings[key]
+                        : inputTemplate.NoBind);
             }
             return template.ToString();
         }

--- a/Snowflake/Emulator/ProcessEmulatorInstance.cs
+++ b/Snowflake/Emulator/ProcessEmulatorInstance.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Snowflake.Game;
+
+namespace Snowflake.Emulator
+{
+    /// <summary>
+    /// Represents an instance of an external emulator process
+    /// </summary>
+    public class ProcessEmulatorInstance : IEmulatorInstance
+    {
+
+        public Process runningEmulatorProcess;
+        public ProcessStartInfo processInfo;
+        public ProcessEmulatorInstance(IGameInfo gameInfo, IEmulatorBridge emulatorBridge, ProcessStartInfo processInfo)
+        {
+            this.InstanceGame = gameInfo;
+            this.InstanceEmulator = emulatorBridge;
+            this.InstanceState = EmulatorInstanceState.InstanceNotStarted;
+            this.processInfo = processInfo;
+            this.InstanceId = $"{this.InstanceGame.UUID}_{Guid.NewGuid()}";
+            this.InstanceTemporaryDirectory = Path.Combine(Path.GetTempPath(), "snowflake", this.InstanceId);
+        }
+        public EmulatorInstanceState InstanceState { get; private set; }
+        public IGameInfo InstanceGame { get; }
+        public string InstanceTemporaryDirectory { get; }
+        public IEmulatorBridge InstanceEmulator { get; }
+        public string InstanceId { get; }
+        public virtual EmulatorInstanceState StartGame()
+        {
+            try
+            {
+                this.runningEmulatorProcess = Process.Start(this.processInfo);
+                this.InstanceState = EmulatorInstanceState.GameRunning;
+            }
+            catch
+            {
+                this.InstanceState = EmulatorInstanceState.InstanceError;
+            }
+            return this.InstanceState;
+        }
+
+        public virtual EmulatorInstanceState PauseGame()
+        {
+            this.InstanceState = EmulatorInstanceState.GamePaused;
+            return this.InstanceState;
+        }
+
+        public virtual EmulatorInstanceState ShutdownGame()
+        {
+            try
+            {
+                this.runningEmulatorProcess.Close();
+                this.InstanceState = EmulatorInstanceState.InstanceShutdown;
+            }
+            catch
+            {
+                this.InstanceState = EmulatorInstanceState.InstanceError;
+            }
+            return this.InstanceState;
+        }
+
+        public virtual EmulatorInstanceState CleanupInstance()
+        {
+            try
+            {
+                if (this.InstanceState != EmulatorInstanceState.InstanceShutdown &&
+                    this.InstanceState != EmulatorInstanceState.InstanceError)
+                {
+                    this.ShutdownGame();
+                }
+                Directory.Delete(this.InstanceTemporaryDirectory, true);
+                this.InstanceState = EmulatorInstanceState.InstanceClosed;
+            }
+            catch
+            {
+                this.InstanceState = EmulatorInstanceState.InstanceError;
+            }
+            return this.InstanceState;
+        }
+
+        public virtual EmulatorInstanceState SendCustomMessage(string message, out string response)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Snowflake/Emulator/ProcessEmulatorInstance.cs
+++ b/Snowflake/Emulator/ProcessEmulatorInstance.cs
@@ -16,13 +16,12 @@ namespace Snowflake.Emulator
     {
 
         public Process runningEmulatorProcess;
-        public ProcessStartInfo processInfo;
-        public ProcessEmulatorInstance(IGameInfo gameInfo, IEmulatorBridge emulatorBridge, ProcessStartInfo processInfo)
+        public ProcessStartInfo ProcessInfo { get; set; }
+        public ProcessEmulatorInstance(IGameInfo gameInfo, IEmulatorBridge emulatorBridge)
         {
             this.InstanceGame = gameInfo;
             this.InstanceEmulator = emulatorBridge;
             this.InstanceState = EmulatorInstanceState.InstanceNotStarted;
-            this.processInfo = processInfo;
             this.InstanceId = $"{this.InstanceGame.UUID}_{Guid.NewGuid()}";
             this.InstanceTemporaryDirectory = Path.Combine(Path.GetTempPath(), "snowflake", this.InstanceId);
         }
@@ -35,7 +34,7 @@ namespace Snowflake.Emulator
         {
             try
             {
-                this.runningEmulatorProcess = Process.Start(this.processInfo);
+                this.runningEmulatorProcess = Process.Start(this.ProcessInfo);
                 this.InstanceState = EmulatorInstanceState.GameRunning;
             }
             catch

--- a/Snowflake/Snowflake.csproj
+++ b/Snowflake/Snowflake.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Emulator\Configuration\ConfigurationFlagSelectValue.cs" />
     <Compile Include="Emulator\Configuration\ConfigurationFlagStore.cs" />
     <Compile Include="Emulator\EmulatorBridge.cs" />
+    <Compile Include="Emulator\ProcessEmulatorInstance.cs" />
     <Compile Include="Game\GameMediaCache.cs" />
     <Compile Include="Game\GameScreenshotCache.cs" />
     <Compile Include="Information\MediaStore\FileMediaStore.cs" />


### PR DESCRIPTION
This Pull Request is a breaking change to the **IEmulatorBridge** API and adds 3 new interfaces

**IEmulatorInstanceManager** is now in charge of the lifetime of an emulator, rather than the bridge plugin handling process start, etc. 

**IEmulatorInstance** represents an instance of an emulator. This is used to control the lifetime of the emulator process, and can represent anything from an external process, or an internal DLL call. It is meant to be overridden and reimplemented by different bridge plugins to suit their needs if needed.

**EmulatorInstanceState** represents the state of an instance of an emulator.

`IEmulatorBridge.StartRom` has been replaced by `IEmulatorBridge.CreateInstance`, which is used to set up the instance without actually starting the ROM. That responsibility now lies in the instance manager.