### PR TITLE
PluginManager: Preload plugin dependencies from plugin data path (fixes #205)

### DIFF
--- a/Snowflake.Service/Service/Manager/PluginManager.cs
+++ b/Snowflake.Service/Service/Manager/PluginManager.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -84,7 +85,7 @@ namespace Snowflake.Service.Manager
             using (var reader = new StreamReader(stream))
             {
                 string file = reader.ReadToEnd();
-                return JsonConvert.DeserializeObject<IDictionary<string, dynamic>>(file)[PluginInfoFields.Name];
+                return JsonConvert.DeserializeObject<IDictionary<string, dynamic>>(file, new JsonSerializerSettings {Culture = CultureInfo.InvariantCulture})[PluginInfoFields.Name];
             }
         }
         private void PreloadDependencies()

--- a/Snowflake.Shell.Windows/Program.cs
+++ b/Snowflake.Shell.Windows/Program.cs
@@ -21,7 +21,7 @@ namespace Snowflake.Shell.Windows
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            using (var mgr = new UpdateManager(@"C:\squirrel\snowflake\rel"))
+         /*   using (var mgr = new UpdateManager(@"C:\squirrel\snowflake\rel"))
             {
                 SquirrelAwareApp.HandleEvents(
                 onInitialInstall: v => mgr.CreateShortcutForThisExe(),
@@ -32,7 +32,7 @@ namespace Snowflake.Shell.Windows
                     Process.Start("snowball.exe install builtins.snowball -l"); //todo call snowball from dll
                 });
 
-            }
+            }*/
             var snowflakeIcon = new ShellIcon();
             SnowflakeEventManager.InitEventSource();
             var snowflakeShell = new SnowflakeShell();

--- a/Snowflake/Plugin/BasePlugin.cs
+++ b/Snowflake/Plugin/BasePlugin.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using Newtonsoft.Json;
@@ -25,7 +26,7 @@ namespace Snowflake.Plugin
             this.PluginAssembly = pluginAssembly;
             this.CoreInstance = coreInstance;
             string file = this.GetStringResource("plugin.json");
-            var pluginInfo = JsonConvert.DeserializeObject<IDictionary<string, dynamic>>(file);
+            var pluginInfo = JsonConvert.DeserializeObject<IDictionary<string, dynamic>>(file, new JsonSerializerSettings() {Culture = CultureInfo.InvariantCulture});
             this.PluginInfo = pluginInfo;
             this.PluginName = this.PluginInfo[PluginInfoFields.Name];
             this.Logger = LogManager.GetLogger(this.PluginName);

--- a/Snowflake/Plugin/BasePlugin.cs
+++ b/Snowflake/Plugin/BasePlugin.cs
@@ -27,7 +27,6 @@ namespace Snowflake.Plugin
             string file = this.GetStringResource("plugin.json");
             var pluginInfo = JsonConvert.DeserializeObject<IDictionary<string, dynamic>>(file);
             this.PluginInfo = pluginInfo;
-            
             this.PluginName = this.PluginInfo[PluginInfoFields.Name];
             this.Logger = LogManager.GetLogger(this.PluginName);
             this.SupportedPlatforms = this.PluginInfo[PluginInfoFields.SupportedPlatforms].ToObject<IList<string>>();


### PR DESCRIPTION
This makes Snowflake load assemblies from the plugin data paths of plugins, so that dependencies can be included in snowballs without leading to overwriting of assemblies in the plugin folder and clogging the folder up with non-plugin assemblies. 

Manually, symlink, or with a script, copy any dependencies into your plugin data folder. They will be loaded on-demand into the default AppDomain prior to the initialization of the entry-point class, and once loaded, .NET takes care of dependency resolution.