### PR TITLE
Remove Reliance on GameLibrary from FileLibrary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 sudo: required
 solution: Snowflake.sln
 mono: none
-dotnet: 2.0.0-preview2-006497
+dotnet: 2.0.0
 dist: trusty 
 osx_image: xcode8.3
 os:

--- a/src/Snowflake.Framework.Primitives/Records/File/IFileLibrary.cs
+++ b/src/Snowflake.Framework.Primitives/Records/File/IFileLibrary.cs
@@ -12,21 +12,6 @@ namespace Snowflake.Records.File
     /// </summary>
     public interface IFileLibrary : IRecordLibrary<IFileRecord>
     {
-
-        /// <summary>
-        /// Get a list of all files relating to a certain game, with
-        /// executable application/romfile-* file types first.
-        /// </summary>
-        /// <returns>A list of all games in the database</returns>
-        IEnumerable<IFileRecord> GetFilesForGame(IGameRecord game);
-
-        /// <summary>
-        /// Get a list of all files relating to a certain game, with
-        /// executable application/romfile-* file types first.
-        /// </summary>
-        /// <returns>A list of all games in the database</returns>
-        IEnumerable<IFileRecord> GetFilesForGame(Guid game);
-
         /// <summary>
         /// Gets a file by its path
         /// </summary>

--- a/src/Snowflake.Framework.Primitives/Records/File/IFileRecord.cs
+++ b/src/Snowflake.Framework.Primitives/Records/File/IFileRecord.cs
@@ -21,10 +21,5 @@ namespace Snowflake.Records.File
         /// The file path of the file
         /// </summary>
         string FilePath { get; }
-
-        /// <summary>
-        /// The game record attached to this Guid.
-        /// </summary>
-        Guid Record { get; }
     }
 }

--- a/src/Snowflake.Framework.Primitives/Records/IRecordLibrary.cs
+++ b/src/Snowflake.Framework.Primitives/Records/IRecordLibrary.cs
@@ -33,5 +33,11 @@ namespace Snowflake.Records
         /// The metadata store associated with this library.
         /// </summary>
         IMetadataLibrary MetadataLibrary { get; }
+
+        /// <summary>
+        /// The name of this library.
+        /// </summary>
+        string LibraryName { get; }
+
     }
 }

--- a/src/Snowflake.Framework.Tests/Records/SqliteFileLibraryTests.cs
+++ b/src/Snowflake.Framework.Tests/Records/SqliteFileLibraryTests.cs
@@ -18,7 +18,7 @@ namespace Snowflake.Records.Tests
         [Fact]
         public void Set_Test()
         {
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", Guid.Empty);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             var library = new SqliteFileLibrary(new SqliteDatabase(Path.GetTempFileName()));
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord.Guid));
             library.Set(fileRecord);
@@ -27,8 +27,8 @@ namespace Snowflake.Records.Tests
         [Fact]
         public void SetMultiple_Test()
         {
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", Guid.Empty);
-            var fileRecord2 = new FileRecord(@"C:\somefile\moretest.txt", "text/plain", Guid.Empty);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
+            var fileRecord2 = new FileRecord(@"C:\somefile\moretest.txt", "text/plain");
 
             var library = new SqliteFileLibrary(new SqliteDatabase(Path.GetTempFileName()));
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord.Guid));
@@ -38,7 +38,7 @@ namespace Snowflake.Records.Tests
         [Fact]
         public void Remove_Test()
         {
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", Guid.Empty);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             var library = new SqliteFileLibrary(new SqliteDatabase(Path.GetTempFileName()));
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord.Guid));
             library.Set(fileRecord);
@@ -50,8 +50,8 @@ namespace Snowflake.Records.Tests
         [Fact]
         public void RemoveMultiple_Test()
         {
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", Guid.Empty);
-            var fileRecord2 = new FileRecord(@"C:\somefile\moretest.txt", "text/plain", Guid.Empty);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
+            var fileRecord2 = new FileRecord(@"C:\somefile\moretest.txt", "text/plain");
 
             var library = new SqliteFileLibrary(new SqliteDatabase(Path.GetTempFileName()));
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord.Guid));
@@ -64,8 +64,8 @@ namespace Snowflake.Records.Tests
         [Fact]
         public void GetMultiple_Test()
         {
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", Guid.Empty);
-            var fileRecord2 = new FileRecord(@"C:\somefile\moretest.txt", "text/plain", Guid.Empty);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
+            var fileRecord2 = new FileRecord(@"C:\somefile\moretest.txt", "text/plain");
 
             var library = new SqliteFileLibrary(new SqliteDatabase(Path.GetTempFileName()));
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord.Guid));
@@ -77,7 +77,7 @@ namespace Snowflake.Records.Tests
         [Fact]
         public void GetAllRecords_Test()
         {
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", Guid.Empty);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             var library = new SqliteFileLibrary(new SqliteDatabase(Path.GetTempFileName()));
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord.Guid));
             library.Set(fileRecord);
@@ -87,7 +87,7 @@ namespace Snowflake.Records.Tests
         [Fact]
         public void GetByMetadata_Test()
         {
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", Guid.Empty);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             var library = new SqliteFileLibrary(new SqliteDatabase(Path.GetTempFileName()));
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord.Guid));
             library.Set(fileRecord);
@@ -97,30 +97,17 @@ namespace Snowflake.Records.Tests
         [Fact]
         public void SearchByMetadata_Test()
         {
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", Guid.Empty);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             var library = new SqliteFileLibrary(new SqliteDatabase(Path.GetTempFileName()));
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord.Guid));
             library.Set(fileRecord);
             Assert.NotEmpty(library.SearchByMetadata("test_metadata", "world"));
         }
-
-        [Fact]
-        public void GetFilesForGame_Test()
-        {
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", Guid.Empty);
-            var library = new SqliteFileLibrary(new SqliteDatabase(Path.GetTempFileName()));
-            fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord.Guid));
-            library.Set(fileRecord);
-            Assert.NotNull(library.GetFilesForGame(Guid.Empty)
-                .FirstOrDefault(g => g.Guid == fileRecord.Guid));
-            Assert.NotEmpty(library.GetFilesForGame(Guid.Empty)
-                .FirstOrDefault(g => g.Guid == fileRecord.Guid).Metadata);
-        }
-
+       
         [Fact]
         public void GetFilesByPath_Test()
         {
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", Guid.Empty);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             var library = new SqliteFileLibrary(new SqliteDatabase(Path.GetTempFileName()));
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord.Guid));
             library.Set(fileRecord);
@@ -130,7 +117,7 @@ namespace Snowflake.Records.Tests
         [Fact]
         public void GetFilesByGuid_Test()
         {
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", Guid.Empty);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             var library = new SqliteFileLibrary(new SqliteDatabase(Path.GetTempFileName()));
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord.Guid));
             library.Set(fileRecord);

--- a/src/Snowflake.Framework.Tests/Records/SqliteGameLibraryTests.cs
+++ b/src/Snowflake.Framework.Tests/Records/SqliteGameLibraryTests.cs
@@ -25,7 +25,7 @@ namespace Snowflake.Records.Tests
             var library = new SqliteGameLibrary(new SqliteDatabase(Path.GetTempFileName()));
 
             var gameRecord = new GameRecord(platformInfo.Object, "Test Game");
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", gameRecord);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord));
 
             gameRecord.Files.Add(fileRecord);
@@ -41,12 +41,12 @@ namespace Snowflake.Records.Tests
             var library = new SqliteGameLibrary(new SqliteDatabase(Path.GetTempFileName()));
 
             var gameRecord = new GameRecord(platformInfo.Object, "Test Game");
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", gameRecord);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord));
             gameRecord.Files.Add(fileRecord);
 
             var gameRecord2 = new GameRecord(platformInfo.Object, "Test Game II");
-            var fileRecord2 = new FileRecord(@"C:\somefile\test.txt", "text/plain", gameRecord2);
+            var fileRecord2 = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             gameRecord2.Files.Add(fileRecord2);
             library.Set(new List<IGameRecord> { gameRecord, gameRecord2 });
         }
@@ -59,7 +59,7 @@ namespace Snowflake.Records.Tests
             var library = new SqliteGameLibrary(new SqliteDatabase(Path.GetTempFileName()));
 
             var gameRecord = new GameRecord(platformInfo.Object, "Test Game");
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", gameRecord);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord));
             gameRecord.Files.Add(fileRecord);
 
@@ -78,12 +78,12 @@ namespace Snowflake.Records.Tests
             var library = new SqliteGameLibrary(new SqliteDatabase(Path.GetTempFileName()));
 
             var gameRecord = new GameRecord(platformInfo.Object, "Test Game");
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", gameRecord);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord));
             gameRecord.Files.Add(fileRecord);
 
             var gameRecord2 = new GameRecord(platformInfo.Object, "Test Game II");
-            var fileRecord2 = new FileRecord(@"C:\somefile\test.txt", "text/plain", gameRecord2);
+            var fileRecord2 = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             gameRecord2.Files.Add(fileRecord2);
             library.Set(new List<IGameRecord> { gameRecord, gameRecord2 });
             Assert.NotEmpty(library.GetAllRecords());
@@ -99,7 +99,7 @@ namespace Snowflake.Records.Tests
             var library = new SqliteGameLibrary(new SqliteDatabase(Path.GetTempFileName()));
 
             var gameRecord = new GameRecord(platformInfo.Object, "Test Game");
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", gameRecord);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord));
 
             gameRecord.Files.Add(fileRecord);
@@ -116,7 +116,7 @@ namespace Snowflake.Records.Tests
             var library = new SqliteGameLibrary(new SqliteDatabase(Path.GetTempFileName()));
 
             var gameRecord = new GameRecord(platformInfo.Object, "Test Game");
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", gameRecord);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord));
 
             gameRecord.Files.Add(fileRecord);
@@ -133,7 +133,7 @@ namespace Snowflake.Records.Tests
             var library = new SqliteGameLibrary(new SqliteDatabase(Path.GetTempFileName()));
 
             var gameRecord = new GameRecord(platformInfo.Object, "Test Game");
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", gameRecord);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord));
 
             gameRecord.Files.Add(fileRecord);
@@ -149,7 +149,7 @@ namespace Snowflake.Records.Tests
             var library = new SqliteGameLibrary(new SqliteDatabase(Path.GetTempFileName()));
 
             var gameRecord = new GameRecord(platformInfo.Object, "Test Game");
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", gameRecord);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord));
 
             gameRecord.Files.Add(fileRecord);
@@ -165,7 +165,7 @@ namespace Snowflake.Records.Tests
             var library = new SqliteGameLibrary(new SqliteDatabase(Path.GetTempFileName()));
 
             var gameRecord = new GameRecord(platformInfo.Object, "Test Game");
-            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain", gameRecord);
+            var fileRecord = new FileRecord(@"C:\somefile\test.txt", "text/plain");
             fileRecord.Metadata.Add("test_metadata", new RecordMetadata("test_metadata", "hello world", fileRecord));
 
             gameRecord.Files.Add(fileRecord);

--- a/src/Snowflake.Framework/Records/File/FileRecord.cs
+++ b/src/Snowflake.Framework/Records/File/FileRecord.cs
@@ -16,7 +16,6 @@ namespace Snowflake.Records.File
         public Guid Guid { get; }
         public string MimeType { get; }
         public string FilePath { get; }
-        public Guid Record => new Guid(this.Metadata["file_linkedrecord"]);
 
         internal FileRecord(Guid guid, IDictionary<string, IRecordMetadata> metadata, string filePath, string mimeType)
         {
@@ -24,28 +23,6 @@ namespace Snowflake.Records.File
             this.FilePath = filePath;
             this.Guid = guid;
             this.Metadata = new MetadataCollection(this.Guid, metadata);
-        }
-
-        internal FileRecord(IFileRecord record, IGameRecord game)
-        {
-            this.MimeType = record.MimeType;
-            this.FilePath = record.FilePath;
-            this.Guid = record.Guid;
-            this.Metadata = record.Metadata;
-            this.Metadata["file_linkedrecord"] = game.Guid.ToString();
-        }
-
-
-        public FileRecord(string filePath, string mimeType, Guid record):
-            this(Guid.NewGuid(), new Dictionary<string, IRecordMetadata>(), filePath, mimeType)
-        {
-            this.Metadata["file_linkedrecord"] = record.ToString();
-        }
-
-
-        public FileRecord(string filePath, string mimeType, IGameRecord gameRecord) :
-            this(filePath, mimeType, gameRecord.Guid)
-        {
         }
 
         public FileRecord(string filePath, string mimeType)

--- a/src/Snowflake.Framework/Records/File/SqliteFileLibrary.cs
+++ b/src/Snowflake.Framework/Records/File/SqliteFileLibrary.cs
@@ -15,7 +15,7 @@ using System.Data.Common;
 
 namespace Snowflake.Records.File
 {
-    internal class SqliteFileLibrary : RecordLibrary<IFileRecord>, IFileLibrary
+    internal class SqliteFileLibrary : SqliteRecordLibrary<IFileRecord>, IFileLibrary
     {
         public override IMetadataLibrary MetadataLibrary { get; }
         private static readonly string[] columns = new[]

--- a/src/Snowflake.Framework/Records/Game/GameRecord.cs
+++ b/src/Snowflake.Framework/Records/Game/GameRecord.cs
@@ -43,7 +43,7 @@ namespace Snowflake.Records.Game
 
         public GameRecord(IPlatformInfo platformInfo, string title, string filename, string mimetype) : this(platformInfo, title)
         {
-            this.Files.Add(new FileRecord(filename, mimetype, this.Guid));
+            this.Files.Add(new FileRecord(filename, mimetype));
         }
     }
 }

--- a/src/Snowflake.Framework/Records/Game/SqliteGameLibrary.cs
+++ b/src/Snowflake.Framework/Records/Game/SqliteGameLibrary.cs
@@ -11,18 +11,18 @@ using System.Data.Common;
 
 namespace Snowflake.Records.Game
 {
-    internal class SqliteGameLibrary : IGameLibrary
+    internal class SqliteGameLibrary : RecordLibrary<IGameRecord>, IGameLibrary
     {
-        public IMetadataLibrary MetadataLibrary { get; }
+        public override IMetadataLibrary MetadataLibrary { get; }
         public IFileLibrary FileLibrary { get; }
-
+        private RecordLibraryJunction<IGameRecord, IFileRecord> FileJunction { get; }
         private readonly ISqlDatabase backingDatabase;
-        public SqliteGameLibrary(ISqlDatabase database, SqliteMetadataLibrary metadataLibrary)
+        public SqliteGameLibrary(ISqlDatabase database, SqliteMetadataLibrary metadataLibrary) : base(database, "games")
         {
             this.backingDatabase = database;
             this.MetadataLibrary = metadataLibrary;
             this.FileLibrary = new SqliteFileLibrary(database, metadataLibrary);
-            this.CreateDatabase();
+            this.FileJunction = this.CreateJunction<IFileRecord>(this.FileLibrary as SqliteFileLibrary);
         }
 
         public SqliteGameLibrary(ISqlDatabase database) : this(database, new SqliteMetadataLibrary(database))
@@ -30,12 +30,7 @@ namespace Snowflake.Records.Game
 
         }
 
-        private void CreateDatabase()
-        {
-            this.backingDatabase.CreateTable("games",
-                "uuid UUID PRIMARY KEY");
-        }
-        public void Set(IGameRecord record)
+        public override void Set(IGameRecord record)
         {
             this.backingDatabase.Execute(dbConnection =>
             {
@@ -43,77 +38,90 @@ namespace Snowflake.Records.Game
                 dbConnection.Execute(@"INSERT OR REPLACE INTO files(uuid, game, path, mimetype) 
                                          VALUES (@Guid, @Record, @FilePath, @MimeType)", record.Files);
                 dbConnection.Execute(@"INSERT OR REPLACE INTO metadata(uuid, record, key, value) 
-                                        VALUES (@Guid, @Record, @Key, @Value)", 
+                                        VALUES (@Guid, @Record, @Key, @Value)",
                                         record.Metadata.Values.Concat(record.Files.SelectMany(m => m.Metadata.Values)));
+                this.FileJunction.MakeRelation(record, record.Files, dbConnection);
             });
         }
 
-        public void Set(IEnumerable<IGameRecord> games)
+        public override void Set(IEnumerable<IGameRecord> games)
         {
             this.backingDatabase.Execute(dbConnection =>
             {
                 var gameRecords = games as IList<IGameRecord> ?? games.ToList();
                 dbConnection.Execute(@"INSERT OR REPLACE INTO games(uuid) VALUES (@Guid)", gameRecords);
                 dbConnection.Execute(@"INSERT OR REPLACE INTO files(uuid, game, path, mimetype) 
-                                       VALUES (@Guid, @Record, @FilePath, @MimeType)", 
+                                       VALUES (@Guid, @Record, @FilePath, @MimeType)",
                                        gameRecords.SelectMany(g => g.Files));
                 dbConnection.Execute(@"INSERT OR REPLACE INTO metadata(uuid, record, key, value) 
                                        VALUES (@Guid, @Record, @Key, @Value)",
                                        gameRecords.SelectMany(g => g.Metadata.Values
                                        .Concat(g.Files.SelectMany(m => m.Metadata.Values)))); //concatenate the files and game metadata at once
+                dbConnection.Execute($@"INSERT OR REPLACE into games_files(games_uuid, files_uuid)
+                                   VALUES (@parentUuid, @childUuid)", gameRecords
+                                   .SelectMany(g => g.Files.Select(f => new { parentUuid = g.Guid, childUuid = f.Guid })));
             });
         }
 
-        public void Remove(IGameRecord record)
+        public override void Remove(IGameRecord record)
         {
             this.Remove(record.Guid);
         }
 
-        public void Remove(IEnumerable<IGameRecord> records)
+        public override void Remove(IEnumerable<IGameRecord> records)
         {
             this.Remove(records.Select(g => g.Guid));
         }
 
-        public void Remove(IEnumerable<Guid> games)
+        public override void Remove(IEnumerable<Guid> games)
         {
-            this.backingDatabase.Execute(@"DELETE FROM games WHERE uuid IN @games;
+            this.backingDatabase.Execute(dbConnection =>
+            {
+                this.FileJunction.DeleteAllRelations(games, dbConnection);
+                dbConnection.Execute(@"DELETE FROM games WHERE uuid IN @games;
                                            DELETE FROM metadata WHERE record IN @games", new { games });
+            });
         }
 
-        public IGameRecord Get(Guid game)
+        public override IGameRecord Get(Guid game)
         {
             const string sql =
                           @"SELECT * FROM games WHERE uuid = @game;
-                            SELECT * FROM files WHERE game = @game;
+                            SELECT files.* FROM games_files JOIN files ON files.uuid = files_uuid AND games_uuid = @game;
                             SELECT * FROM metadata WHERE record IN 
                                 (SELECT uuid FROM files WHERE game = @game
                                  UNION ALL SELECT uuid from games WHERE uuid = @game)";
-            return this.GetSingleByQuery(sql, new {game});
+            return this.GetSingleByQuery(sql, new { game });
         }
 
-        public IEnumerable<IGameRecord> Get(IEnumerable<Guid> games)
+        public override IEnumerable<IGameRecord> Get(IEnumerable<Guid> games)
         {
             const string sql = @"SELECT * from games WHERE uuid IN @games;
-                                 SELECT * FROM files WHERE game IN @games;
+                                 SELECT files.* FROM games_files JOIN files ON files.uuid = files_uuid AND games_uuid IN @games;
                                  SELECT * FROM metadata WHERE record IN 
                                         (SELECT uuid from games WHERE uuid IN @games 
                                         UNION ALL SELECT uuid FROM files WHERE game IN @games)";
             return this.GetMultipleByQuery(sql, games);
         }
 
-        public void Remove(Guid game)
+        public override void Remove(Guid game)
         {
-            this.backingDatabase.Execute(@"DELETE FROM games WHERE uuid = @game;
-                                           DELETE FROM metadata WHERE record = @game", new { game });
+            this.backingDatabase.Execute(dbConnection => {
+                this.FileJunction.DeleteAllRelations(game, dbConnection);
+                dbConnection.Execute(@"DELETE FROM games WHERE uuid = @game;
+                                       DELETE FROM metadata WHERE record = @game", new { game });
+                }
+             );
             //because file record guids are derived from game library, they can be safely left alone
         }
 
-        public IEnumerable<IGameRecord> SearchByMetadata(string key, string likeValue)
+        //select files.* from games_files join files on files.uuid = files_uuid and games_uuid = x'45379b93e1eb064a9bb63deda29a242d'
+        public override IEnumerable<IGameRecord> SearchByMetadata(string key, string likeValue)
         {
             const string sql = @"SELECT * FROM games WHERE uuid IN 
                                 (SELECT record FROM metadata WHERE key = @key AND value LIKE @likeValue);
 
-                                SELECT * FROM files WHERE game IN 
+                                SELECT files.* FROM games_files JOIN files ON files.uuid = files_uuid AND games_uuid IN 
                                     (SELECT uuid FROM games WHERE uuid IN 
                                         (SELECT record FROM metadata WHERE key = @key AND value LIKE @likeValue));
 
@@ -125,12 +133,12 @@ namespace Snowflake.Records.Game
             return this.GetMultipleByQuery(sql, new {key, likeValue = $"%{likeValue}%"});
         }
 
-        public IEnumerable<IGameRecord> GetByMetadata(string key, string exactValue)
+        public override IEnumerable<IGameRecord> GetByMetadata(string key, string exactValue)
         {
             const string sql = @"SELECT * FROM games WHERE uuid IN 
                                 (SELECT record FROM metadata WHERE key = @key AND value = @exactValue);
 
-                                SELECT * FROM files WHERE game IN 
+                                SELECT files.* FROM games_files JOIN files ON files.uuid = files_uuid AND games_uuid IN  
                                     (SELECT uuid FROM games WHERE uuid IN 
                                         (SELECT record FROM metadata WHERE key = @key AND value = @exactValue));
 
@@ -142,10 +150,10 @@ namespace Snowflake.Records.Game
 
         }
 
-        public IEnumerable<IGameRecord> GetAllRecords()
+        public override IEnumerable<IGameRecord> GetAllRecords()
         {
             const string sql = @"SELECT * FROM games;
-                                 SELECT * FROM files WHERE game IN (SELECT uuid FROM games);
+                                 SELECT files.* FROM games_files JOIN files ON files.uuid = files_uuid AND games_uuid IN (SELECT uuid FROM games);
                                  SELECT * FROM metadata WHERE record IN 
                                         (SELECT uuid FROM games 
                                         UNION ALL SELECT uuid FROM files WHERE game IN (SELECT uuid FROM games))";

--- a/src/Snowflake.Framework/Records/Game/SqliteGameLibrary.cs
+++ b/src/Snowflake.Framework/Records/Game/SqliteGameLibrary.cs
@@ -34,6 +34,7 @@ namespace Snowflake.Records.Game
         {
             this.backingDatabase.Execute(dbConnection =>
             {
+                this.FileJunction.DeleteAllRelations(record, dbConnection);  // ensure relations do not conflict.
                 dbConnection.Execute(@"INSERT OR REPLACE INTO games(uuid) VALUES (@Guid)", record);
                 dbConnection.Execute(@"INSERT OR REPLACE INTO files(uuid, path, mimetype) 
                                          VALUES (@Guid, @FilePath, @MimeType)", record.Files);
@@ -49,6 +50,7 @@ namespace Snowflake.Records.Game
             this.backingDatabase.Execute(dbConnection =>
             {
                 var gameRecords = games as IList<IGameRecord> ?? games.ToList();
+                this.FileJunction.DeleteAllRelations(games.Select(g => g.Guid), dbConnection); // ensure relations do not conflict.
                 dbConnection.Execute(@"INSERT OR REPLACE INTO games(uuid) VALUES (@Guid)", gameRecords);
                 dbConnection.Execute(@"INSERT OR REPLACE INTO files(uuid, path, mimetype) 
                                        VALUES (@Guid, @FilePath, @MimeType)",

--- a/src/Snowflake.Framework/Records/Game/SqliteGameLibrary.cs
+++ b/src/Snowflake.Framework/Records/Game/SqliteGameLibrary.cs
@@ -11,7 +11,7 @@ using System.Data.Common;
 
 namespace Snowflake.Records.Game
 {
-    internal class SqliteGameLibrary : RecordLibrary<IGameRecord>, IGameLibrary
+    internal class SqliteGameLibrary : SqliteRecordLibrary<IGameRecord>, IGameLibrary
     {
         public override IMetadataLibrary MetadataLibrary { get; }
         public IFileLibrary FileLibrary { get; }

--- a/src/Snowflake.Framework/Records/RecordLibrary.cs
+++ b/src/Snowflake.Framework/Records/RecordLibrary.cs
@@ -1,0 +1,47 @@
+﻿using Snowflake.Persistence;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Snowflake.Records.Metadata;
+
+namespace Snowflake.Records
+{
+    internal abstract class RecordLibrary<TRecord> : IRecordLibrary<TRecord> where TRecord : IRecord 
+    {
+        private readonly ISqlDatabase backingDatabase;
+        public string LibraryName { get; }
+        public abstract IMetadataLibrary MetadataLibrary { get; }
+
+        public RecordLibrary(ISqlDatabase database, string libraryName, params string[] columns)
+        {
+            this.backingDatabase = database;
+            this.LibraryName = libraryName;
+            this.CreateDatabase(columns);
+        }
+
+        private void CreateDatabase(string[] columns)
+        {
+            this.backingDatabase.CreateTable(this.LibraryName,
+                columns.Prepend("uuid UUID PRIMARY KEY").ToArray());
+        }
+
+     
+        protected RecordLibraryJunction<TRecord, T> CreateJunction<T>(RecordLibrary<T> junctionWith) where T: IRecord
+        {
+            return new RecordLibraryJunction<TRecord, T>(this.backingDatabase, this, junctionWith);
+        }
+
+        public abstract IEnumerable<TRecord> SearchByMetadata(string key, string likeValue);
+        public abstract IEnumerable<TRecord> GetByMetadata(string key, string exactValue);
+        public abstract void Set(TRecord record);
+        public abstract void Set(IEnumerable<TRecord> records);
+        public abstract void Remove(TRecord record);
+        public abstract void Remove(IEnumerable<TRecord> records);
+        public abstract void Remove(Guid guid);
+        public abstract void Remove(IEnumerable<Guid> guids);
+        public abstract TRecord Get(Guid guid);
+        public abstract IEnumerable<TRecord> Get(IEnumerable<Guid> guids);
+        public abstract IEnumerable<TRecord> GetAllRecords();
+    }
+}

--- a/src/Snowflake.Framework/Records/RecordLibraryJunction.cs
+++ b/src/Snowflake.Framework/Records/RecordLibraryJunction.cs
@@ -26,8 +26,8 @@ namespace Snowflake.Records
         private void CreateDatabase()
         {
             this.backingDatabase.CreateTable(this.JunctionName,
-                $"{this.ParentLibrary.LibraryName}_uuid REFERENCES {this.ParentLibrary.LibraryName}(uuid)",
-                $"{this.ChildLibrary.LibraryName}_uuid REFERENCES {this.ChildLibrary.LibraryName}(uuid)",
+                $"{this.ParentLibrary.LibraryName}_uuid UUID REFERENCES {this.ParentLibrary.LibraryName}(uuid)",
+                $"{this.ChildLibrary.LibraryName}_uuid UUID REFERENCES {this.ChildLibrary.LibraryName}(uuid)",
                 $"PRIMARY KEY ({this.ParentLibrary.LibraryName}_uuid, {this.ChildLibrary.LibraryName}_uuid)"
             );
         }

--- a/src/Snowflake.Framework/Records/RecordLibraryJunction.cs
+++ b/src/Snowflake.Framework/Records/RecordLibraryJunction.cs
@@ -1,0 +1,57 @@
+﻿using Dapper;
+using Snowflake.Persistence;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+
+namespace Snowflake.Records
+{
+    internal class RecordLibraryJunction <T1, T2> where T1 : IRecord where T2 : IRecord
+    {
+        private readonly ISqlDatabase backingDatabase;
+        public string JunctionName { get; }
+        private RecordLibrary<T1> ParentLibrary { get; }
+        private RecordLibrary<T2> ChildLibrary { get; }
+        public RecordLibraryJunction(ISqlDatabase database, RecordLibrary<T1> parentLibrary, RecordLibrary<T2> childLibrary)
+        {
+            this.backingDatabase = database;
+            this.JunctionName = $"{parentLibrary.LibraryName}_{childLibrary.LibraryName}";
+            this.ParentLibrary = parentLibrary;
+            this.ChildLibrary = childLibrary;
+            this.CreateDatabase();
+        }
+
+        private void CreateDatabase()
+        {
+            this.backingDatabase.CreateTable(this.JunctionName,
+                $"{this.ParentLibrary.LibraryName}_uuid REFERENCES {this.ParentLibrary.LibraryName}(uuid)",
+                $"{this.ChildLibrary.LibraryName}_uuid REFERENCES {this.ChildLibrary.LibraryName}(uuid)",
+                $"PRIMARY KEY ({this.ParentLibrary.LibraryName}_uuid, {this.ChildLibrary.LibraryName}_uuid)"
+            );
+        }
+
+        //select files.* from games_files join files on files.uuid = files_uuid and games_uuid = x'45379b93e1eb064a9bb63deda29a242d'
+
+        public void MakeRelation(T1 parentRelation, IEnumerable<T2> childRelation, IDbConnection dbConnection)
+        {
+            dbConnection.Execute($@"INSERT OR REPLACE into {this.JunctionName}({this.ParentLibrary.LibraryName}_uuid, {this.ChildLibrary.LibraryName}_uuid)
+                                   VALUES (@parentUuid, @childUuid)", childRelation.Select( c => new { parentUuid = parentRelation.Guid, childUuid = c.Guid} ));
+        }
+      
+        public void DeleteAllRelations(T1 parentRelation, IDbConnection dbConnection)
+        {
+            dbConnection.Execute($@"DELETE FROM {this.JunctionName} WHERE {this.ParentLibrary.LibraryName}_uuid = @Guid", parentRelation);
+        }
+        public void DeleteAllRelations(Guid parentRelation, IDbConnection dbConnection)
+        {
+            dbConnection.Execute($@"DELETE FROM {this.JunctionName} WHERE {this.ParentLibrary.LibraryName}_uuid = @Guid", new { Guid = parentRelation });
+        }
+
+        public void DeleteAllRelations(IEnumerable<Guid> parentRelation, IDbConnection dbConnection)
+        {
+            dbConnection.Execute($@"DELETE FROM {this.JunctionName} WHERE {this.ParentLibrary.LibraryName}_uuid IN @Guids", new { Guids = parentRelation });
+        }
+    }
+}

--- a/src/Snowflake.Framework/Records/SqliteRecordLibrary.cs
+++ b/src/Snowflake.Framework/Records/SqliteRecordLibrary.cs
@@ -7,13 +7,17 @@ using Snowflake.Records.Metadata;
 
 namespace Snowflake.Records
 {
-    internal abstract class RecordLibrary<TRecord> : IRecordLibrary<TRecord> where TRecord : IRecord 
+    /// <summary>
+    /// An Sqlite backed record library that allows junctions.
+    /// </summary>
+    /// <typeparam name="TRecord"></typeparam>
+    internal abstract class SqliteRecordLibrary<TRecord> : IRecordLibrary<TRecord> where TRecord : IRecord 
     {
         private readonly ISqlDatabase backingDatabase;
         public string LibraryName { get; }
         public abstract IMetadataLibrary MetadataLibrary { get; }
 
-        public RecordLibrary(ISqlDatabase database, string libraryName, params string[] columns)
+        public SqliteRecordLibrary(ISqlDatabase database, string libraryName, params string[] columns)
         {
             this.backingDatabase = database;
             this.LibraryName = libraryName;
@@ -27,7 +31,13 @@ namespace Snowflake.Records
         }
 
      
-        protected RecordLibraryJunction<TRecord, T> CreateJunction<T>(RecordLibrary<T> junctionWith) where T: IRecord
+        /// <summary>
+        /// Creates a junction between two record libraries
+        /// </summary>
+        /// <typeparam name="T">The type of the other record</typeparam>
+        /// <param name="junctionWith">The other record library to junction with.</param>
+        /// <returns>A record junction</returns>
+        protected RecordLibraryJunction<TRecord, T> CreateJunction<T>(SqliteRecordLibrary<T> junctionWith) where T: IRecord
         {
             return new RecordLibraryJunction<TRecord, T>(this.backingDatabase, this, junctionWith);
         }

--- a/src/Snowflake.Framework/Scraper/ScrapeEngine.cs
+++ b/src/Snowflake.Framework/Scraper/ScrapeEngine.cs
@@ -50,7 +50,7 @@ namespace Snowflake.Scraper
         {
             var gr = new GameRecord(this.stoneProvider.Platforms[fileRecord.Metadata[FileMetadataKeys.RomPlatform]], 
                 fileRecord.Metadata[FileMetadataKeys.RomCanonicalTitle]);
-            gr.Files.Add(new FileRecord(fileRecord, gr));
+            gr.Files.Add(fileRecord);
             //merge scrape resu;ts
             var bestMatch = (from provider in this.providers.MetadataProviders.AsParallel()
                              from result in provider.Query(fileRecord.Metadata)

--- a/src/Snowflake.Support.Caching.KeyedImageCache/KeyedImageCache.cs
+++ b/src/Snowflake.Support.Caching.KeyedImageCache/KeyedImageCache.cs
@@ -64,7 +64,7 @@ namespace Snowflake.Support.Caching.KeyedImageCache
                     resizedImage.Save(path, ImageFormat.Jpeg);
                 }
             }
-            var record = new FileRecord(path, "image/jpeg", recordGuid);
+            var record = new FileRecord(path, "image/jpeg");
             var data = new List<IRecordMetadata>()
             {
                 {new RecordMetadata(ImageMetadataKeys.CacheId, cacheId.ToString(), record.Guid)},

--- a/src/Snowflake.Support.Remoting/Resources/Games/GameFilesLibraryRoot.cs
+++ b/src/Snowflake.Support.Remoting/Resources/Games/GameFilesLibraryRoot.cs
@@ -27,7 +27,7 @@ namespace Snowflake.Resources.Games
         public IGameRecord CreateFile(Guid gameGuid, string path, string mimetype)
         {
             if (path == null || mimetype == null) throw new InvalidFileException();
-            var file = new FileRecord(path, mimetype, gameGuid);
+            var file = new FileRecord(path, mimetype);
             this.Library.FileLibrary.Set(file);
             return this.Library.Get(gameGuid);
         }


### PR DESCRIPTION
Uses a junction table rather than an explicit record column to store the relation between Games and Files. `FileRecord`s now have zero dependence on `GameRecord`, and constructors relating to the creation of FileRecords with a linked record have been removed.