### PR TITLE
Input: Add support for the Gyroscope ControllerElement as of Stone 7.1.1

### DIFF
--- a/src/Snowflake.Framework.Primitives/Input/Controller/ControllerElement.cs
+++ b/src/Snowflake.Framework.Primitives/Input/Controller/ControllerElement.cs
@@ -452,6 +452,12 @@ namespace Snowflake.Input.Controller
         /// </summary>
         Touchscreen,
 
+        /// <summary>
+        /// A 3 axis rotation gyroscope of unspecified precision,
+        /// where input can be expressed as a vector of 3 coordinates X, Y, and Z
+        /// </summary>
+        Gyroscope,
+
         // The following elements are keyboard keys.
         // By convention, these keys mappable from K -> K.
         // Instead, they can only be mapped from K -> C where

--- a/src/Snowflake.Framework.Primitives/Input/Controller/ControllerElementType.cs
+++ b/src/Snowflake.Framework.Primitives/Input/Controller/ControllerElementType.cs
@@ -81,5 +81,11 @@ namespace Snowflake.Input.Controller
         /// are only concerned with a single matrix due to the lack of multi-touch support.
         /// </summary>
         Touchscreen,
+
+        /// <summary>
+        /// A 3 axis rotation gyroscope of unspecified precision, 
+        /// where input can be expressed as a vector of 3 coordinates X, Y, and Z
+        /// </summary>
+        Gyroscope,
     }
 }

--- a/src/Snowflake.Framework.Primitives/Input/Controller/IControllerElementCollection.cs
+++ b/src/Snowflake.Framework.Primitives/Input/Controller/IControllerElementCollection.cs
@@ -446,11 +446,10 @@ namespace Snowflake.Input.Controller
         /// </summary>
         IControllerElementInfo Touchscreen { get; }
 
-         /// <summary>
+        /// <summary>
         /// Gets a 3 axis rotation gyroscope of unspecified precision, 
         /// where input can be expressed as a vector of 3 coordinates X, Y, and Z
         /// </summary>
-
         IControllerElementInfo Gyroscope { get; }
 
         /// <summary>

--- a/src/Snowflake.Framework.Primitives/Input/Controller/IControllerElementCollection.cs
+++ b/src/Snowflake.Framework.Primitives/Input/Controller/IControllerElementCollection.cs
@@ -446,6 +446,13 @@ namespace Snowflake.Input.Controller
         /// </summary>
         IControllerElementInfo Touchscreen { get; }
 
+         /// <summary>
+        /// Gets a 3 axis rotation gyroscope of unspecified precision, 
+        /// where input can be expressed as a vector of 3 coordinates X, Y, and Z
+        /// </summary>
+
+        IControllerElementInfo Gyroscope { get; }
+
         /// <summary>
         /// Indexer accessor for the elements in this collection.
         /// If not present, should return null.

--- a/src/Snowflake.Framework/Input/Controller/ControllerElementCollection.cs
+++ b/src/Snowflake.Framework/Input/Controller/ControllerElementCollection.cs
@@ -261,6 +261,9 @@ namespace Snowflake.Input.Controller
         /// <inheritdoc/>
         public IControllerElementInfo Touchscreen => this[ControllerElement.Touchscreen];
 
+        /// <inheritdoc/>
+        public IControllerElementInfo Gyroscope => this[ControllerElement.Gyroscope];
+
         private readonly IDictionary<ControllerElement, IControllerElementInfo> controllerElements;
 
         /// <inheritdoc/>


### PR DESCRIPTION
Stone becomes stable as of 7.1.0, introducing a breaking change from 7.0.0-alpha.12 (legal due to unstable tag), with the Gyroscope ControllerElement.

This does not pull the 7.1.0 definitions however, only updating the internal Stone API. 7.0.0-alpha.12 definitions are still in use for now.

Hopefully should not cause any database issues.
