### PR TITLE
SDK: Formalize a 'Snowflake SDK' using MSBuild Project SDKs

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -51,7 +51,7 @@ Task("PackModules")
   .DoesForEach(ParseSolution(new FilePath("../src/Snowflake.sln"))
                .GetProjects(), project => {
     var projectProps = ParseProject(project.Path, "debug");
-    if (projectProps.NetCore?.DotNetCliToolReferences?.Any(r => r.Name == "dotnet-snowflake") == true) {
+    if (projectProps.NetCore?.Sdk.StartsWith("Snowflake.Framework.Sdk/") == true && FileExists(project.Path.GetDirectory().CombineWithFilePath("module.json"))) {
         Information($"Building {projectProps.AssemblyName}");
         DotNetCoreTool(project.Path, "snowflake", "build");
         Information($"Packing module..");
@@ -118,6 +118,7 @@ Task("Codecov")
 
 Task("Bootstrap")
   .IsDependentOn("PackModules")
+  .IsDependentOn("BuildTooling")
   .Does(() => {
     DotNetCoreExecute("./snowflake-cli/dotnet-snowflake.dll", $"install-all -d ./out");
   });

--- a/src/Snowflake.Bootstrap.Windows/Snowflake.Bootstrap.Windows.csproj
+++ b/src/Snowflake.Bootstrap.Windows/Snowflake.Bootstrap.Windows.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SQLite" Version="2.2.0" />
+    <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Snowflake.Bootstrap.Windows/Snowflake.Bootstrap.Windows.csproj
+++ b/src/Snowflake.Bootstrap.Windows/Snowflake.Bootstrap.Windows.csproj
@@ -15,10 +15,6 @@
     <AdditionalFiles Include="..\stylecop.json" />
 
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SQLite" Version="2.2.0" />
-    <PackageReference Include="NLog" Version="4.5.11" />
-  </ItemGroup>
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\Snowflake.ruleset</CodeAnalysisRuleSet>

--- a/src/Snowflake.Framework.Sdk/Sdk/Sdk.props
+++ b/src/Snowflake.Framework.Sdk/Sdk/Sdk.props
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <_SnowflakeUseDevelopmentSDK>false</_SnowflakeUseDevelopmentSDK>
     <SnowflakeSDKAssembliesVersion>1.0.0-alpha.*</SnowflakeSDKAssembliesVersion>
-    <SnowflakeSDKToolingVersion>1.5.1</SnowflakeSDKToolingVersion>
+    <SnowflakeSDKToolingVersion>1.6.0</SnowflakeSDKToolingVersion>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(_SnowflakeUseDevelopmentSDK)' == 'false' ">
@@ -25,6 +25,13 @@
 
    <ItemGroup>
     <DotNetCliToolReference Include="dotnet-snowflake" Version="$(SnowflakeSDKToolingVersion)" />
+  </ItemGroup>
+
+
+  <ItemGroup Condition="Exists('module.json')">
+    <None Update="module.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Snowflake.Framework.Sdk/Sdk/Sdk.props
+++ b/src/Snowflake.Framework.Sdk/Sdk/Sdk.props
@@ -4,6 +4,7 @@
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
  
   <PropertyGroup>
+    <_SnowflakeUseDevelopmentSDK>false</_SnowflakeUseDevelopmentSDK>
     <SnowflakeSDKAssembliesVersion>1.0.0-alpha.*</SnowflakeSDKAssembliesVersion>
     <SnowflakeSDKToolingVersion>1.5.1</SnowflakeSDKToolingVersion>
   </PropertyGroup>

--- a/src/Snowflake.Framework.Services/Snowflake.Framework.Services.csproj
+++ b/src/Snowflake.Framework.Services/Snowflake.Framework.Services.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Include="NLog" Version="4.5.11" PrivateAssets="All"/>
+    <PackageReference Include="NLog" Version="4.5.11" PrivateAssets="Compile"/>
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.2.0" PrivateAssets="Compile"/>
     <PackageReference Include="GraphQL.Server.Transports.WebSockets" Version="3.2.0" PrivateAssets="Compile"/>
   </ItemGroup>

--- a/src/Snowflake.Framework.Tests.DummyComposable/Snowflake.Framework.Tests.DummyComposable.csproj
+++ b/src/Snowflake.Framework.Tests.DummyComposable/Snowflake.Framework.Tests.DummyComposable.csproj
@@ -1,16 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
     <ProjectReference Include="..\Snowflake.Framework.Tests.DummyComposableInterface\Snowflake.Framework.Tests.DummyComposableInterface.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Snowflake.Framework.Tests.DummyComposable/Snowflake.Framework.Tests.DummyComposable.csproj
+++ b/src/Snowflake.Framework.Tests.DummyComposable/Snowflake.Framework.Tests.DummyComposable.csproj
@@ -14,11 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/Snowflake.Framework.Tests.DummyComposableInterface/Snowflake.Framework.Tests.DummyComposableInterface.csproj
+++ b/src/Snowflake.Framework.Tests.DummyComposableInterface/Snowflake.Framework.Tests.DummyComposableInterface.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>

--- a/src/Snowflake.Framework.Tests.InvalidComposable/Snowflake.Framework.Tests.InvalidComposable.csproj
+++ b/src/Snowflake.Framework.Tests.InvalidComposable/Snowflake.Framework.Tests.InvalidComposable.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -11,6 +11,7 @@
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
+  
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\Snowflake.ruleset</CodeAnalysisRuleSet>
     <LangVersion>8.0</LangVersion>

--- a/src/Snowflake.Framework.Tests.InvalidComposable/Snowflake.Framework.Tests.InvalidComposable.csproj
+++ b/src/Snowflake.Framework.Tests.InvalidComposable/Snowflake.Framework.Tests.InvalidComposable.csproj
@@ -14,11 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/Snowflake.Framework.Tests.InvalidComposable/Snowflake.Framework.Tests.InvalidComposable.csproj
+++ b/src/Snowflake.Framework.Tests.InvalidComposable/Snowflake.Framework.Tests.InvalidComposable.csproj
@@ -1,18 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
     <ProjectReference Include="..\Snowflake.Framework.Tests.DummyComposableInterface\Snowflake.Framework.Tests.DummyComposableInterface.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
-
+  
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>

--- a/src/Snowflake.Framework.Tests/Snowflake.Framework.Tests.csproj
+++ b/src/Snowflake.Framework.Tests/Snowflake.Framework.Tests.csproj
@@ -50,7 +50,6 @@
     <ProjectReference Include="..\Snowflake.Support.PluginManager\Snowflake.Support.PluginManager.csproj" />
     <ProjectReference Include="..\Snowflake.Support.ShiragameProvider\Snowflake.Support.ShiragameProvider.csproj" />
     <ProjectReference Include="..\Snowflake.Support.StoneProvider\Snowflake.Support.StoneProvider.csproj" />
-    <ProjectReference Include="..\Snowflake.Support.StoreProviders\Snowflake.Support.StoreProviders.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Snowflake.Framework/Snowflake.Framework.csproj
+++ b/src/Snowflake.Framework/Snowflake.Framework.csproj
@@ -13,12 +13,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.3.1" PrivateAssets="Compile"/>
-    <PackageReference Include="Dapper" Version="1.50.5" PrivateAssets="Compile"/>
-    <PackageReference Include="Enums.NET" Version="2.3.2" PrivateAssets="Compile"/>
+    <PackageReference Include="Castle.Core" Version="4.3.1" PrivateAssets="Compile" />
+    <PackageReference Include="Dapper" Version="1.50.5" PrivateAssets="Compile" />
+    <PackageReference Include="Enums.NET" Version="2.3.2" PrivateAssets="Compile" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" PrivateAssets="Compile"/>
-    <PackageReference Include="Zio" Version="0.7.2"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" PrivateAssets="Compile" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.0" />
+    <PackageReference Include="Zio" Version="0.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Snowflake.Framework/Snowflake.Framework.csproj
+++ b/src/Snowflake.Framework/Snowflake.Framework.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Castle.Core" Version="4.3.1" PrivateAssets="Compile" />
     <PackageReference Include="Dapper" Version="1.50.5" PrivateAssets="Compile" />
     <PackageReference Include="Enums.NET" Version="2.3.2" PrivateAssets="Compile" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.0" PrivateAssets="Compile"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" PrivateAssets="Compile" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.0" />
     <PackageReference Include="Zio" Version="0.7.2" />

--- a/src/Snowflake.Plugin.Debug.GraphQLVisualizers/Snowflake.Plugin.Debug.GraphQLVisualizers.csproj
+++ b/src/Snowflake.Plugin.Debug.GraphQLVisualizers/Snowflake.Plugin.Debug.GraphQLVisualizers.csproj
@@ -1,25 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework.Remoting\Snowflake.Framework.Remoting.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-
-  </ItemGroup>
+  
+ 
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>

--- a/src/Snowflake.Plugin.Emulators.RetroArch/Snowflake.Plugin.Emulators.RetroArch.csproj
+++ b/src/Snowflake.Plugin.Emulators.RetroArch/Snowflake.Plugin.Emulators.RetroArch.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -19,14 +19,6 @@
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>

--- a/src/Snowflake.Plugin.Scraping.FileSignatures/Snowflake.Plugin.Scraping.FileSignatures.csproj
+++ b/src/Snowflake.Plugin.Scraping.FileSignatures/Snowflake.Plugin.Scraping.FileSignatures.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -14,23 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
-
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+  
 
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="DiscUtils.Core" Version="0.14.0-alpha234" />

--- a/src/Snowflake.Plugin.Scraping.FileSignatures/Snowflake.Plugin.Scraping.FileSignatures.csproj
+++ b/src/Snowflake.Plugin.Scraping.FileSignatures/Snowflake.Plugin.Scraping.FileSignatures.csproj
@@ -17,8 +17,6 @@
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 
-  
-
 
   <ItemGroup>
     <PackageReference Include="DiscUtils.Core" Version="0.14.0-alpha234" />

--- a/src/Snowflake.Plugin.Scraping.TheGamesDb/Snowflake.Plugin.Scraping.TheGamesDb.csproj
+++ b/src/Snowflake.Plugin.Scraping.TheGamesDb/Snowflake.Plugin.Scraping.TheGamesDb.csproj
@@ -1,20 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+  
 </Project>

--- a/src/Snowflake.Support.Execution.Providers/Snowflake.Support.Execution.Providers.csproj
+++ b/src/Snowflake.Support.Execution.Providers/Snowflake.Support.Execution.Providers.csproj
@@ -1,21 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
 </Project>

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Snowflake.Support.GraphQLFrameworkQueries.csproj
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Snowflake.Support.GraphQLFrameworkQueries.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -8,25 +8,8 @@
   <ItemGroup>
     <PackageReference Include="GraphQL" Version="2.4.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework.Remoting\Snowflake.Framework.Remoting.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <PropertyGroup>
-    <DependsOnNETStandard>true</DependsOnNETStandard>
-  </PropertyGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
-  <ItemGroup>
+  
+<ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
 
   </ItemGroup>

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Types/ControllerLayout/ControllerLayoutGraphType.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Types/ControllerLayout/ControllerLayoutGraphType.cs
@@ -14,7 +14,9 @@ namespace Snowflake.Support.Remoting.GraphQL.Types.ControllerLayout
             Name = "ControllerLayout";
             Description = "A Stone Controller Layout";
             Field(c => c.FriendlyName).Description("The Friendly Name of this controller layout");
-            Field<StringGraphType>("layoutId", resolve: c => c.Source.LayoutId, description: "The Stone Layout ID for this controller layout");
+            Field<StringGraphType>("layoutId", 
+                resolve: c => (string)c.Source.LayoutId, 
+                description: "The Stone Layout ID for this controller layout");
             Field<ListGraphType<StringGraphType>>(
                 "platforms",
                 description: "The platforms this controller supports.",

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Types/InputDevice/Mapped/MappedControllerElementCollectionGraphType.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Types/InputDevice/Mapped/MappedControllerElementCollectionGraphType.cs
@@ -13,8 +13,7 @@ namespace Snowflake.Support.Remoting.GraphQL.Types.InputDevice.Mapped
             Name = "ControllerElementMappings";
             Description =
                 "A collection of mapped controller elements. Essentially a mapping profile from a real device to an emulated virtual device.";
-            Field(c => c.ControllerId)
-                .Description("The Stone Controller ID of the emulated controller this collection maps to.");
+            Field<StringGraphType>("controllerId", resolve: c => c.Source.ControllerId, description: "The Stone Controller ID of the emulated controller this collection maps to.");
             Field(c => c.DeviceId).Description("The Controller ID of the real device this collection maps from.");
             Field<ListGraphType<MappedControllerElementGraphType>>("mappings",
                 description: "The set of mappings that map each element from the real device to the emulated device.",

--- a/src/Snowflake.Support.PluginManager/Snowflake.Support.PluginManager.csproj
+++ b/src/Snowflake.Support.PluginManager/Snowflake.Support.PluginManager.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -6,20 +6,6 @@
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>

--- a/src/Snowflake.Support.Remoting.Electron.ThemeProvider/Snowflake.Support.Remoting.Electron.ThemeProvider.csproj
+++ b/src/Snowflake.Support.Remoting.Electron.ThemeProvider/Snowflake.Support.Remoting.Electron.ThemeProvider.csproj
@@ -1,27 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GraphQL" Version="2.4.0" />
-  </ItemGroup>
+  
 
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework.Remoting\Snowflake.Framework.Remoting.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 
 </Project>

--- a/src/Snowflake.Support.Scraping.RecordScrapeEngine/Snowflake.Support.Scraping.RecordScrapeEngine.csproj
+++ b/src/Snowflake.Support.Scraping.RecordScrapeEngine/Snowflake.Support.Scraping.RecordScrapeEngine.csproj
@@ -5,7 +5,6 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
-  
 
 
 </Project>

--- a/src/Snowflake.Support.Scraping.RecordScrapeEngine/Snowflake.Support.Scraping.RecordScrapeEngine.csproj
+++ b/src/Snowflake.Support.Scraping.RecordScrapeEngine/Snowflake.Support.Scraping.RecordScrapeEngine.csproj
@@ -1,22 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
+  
 
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 
 </Project>

--- a/src/Snowflake.Support.Scraping.RecordTraversers/Snowflake.Support.Scraping.RecordTraversers.csproj
+++ b/src/Snowflake.Support.Scraping.RecordTraversers/Snowflake.Support.Scraping.RecordTraversers.csproj
@@ -9,8 +9,5 @@
     <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
     <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
   </ItemGroup>
-  
-  
-
 
 </Project>

--- a/src/Snowflake.Support.Scraping.RecordTraversers/Snowflake.Support.Scraping.RecordTraversers.csproj
+++ b/src/Snowflake.Support.Scraping.RecordTraversers/Snowflake.Support.Scraping.RecordTraversers.csproj
@@ -5,9 +5,4 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/src/Snowflake.Support.Scraping.RecordTraversers/Snowflake.Support.Scraping.RecordTraversers.csproj
+++ b/src/Snowflake.Support.Scraping.RecordTraversers/Snowflake.Support.Scraping.RecordTraversers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -9,13 +9,8 @@
     <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
     <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+  
+  
+
 
 </Project>

--- a/src/Snowflake.Support.ShiragameProvider/Snowflake.Support.ShiragameProvider.csproj
+++ b/src/Snowflake.Support.ShiragameProvider/Snowflake.Support.ShiragameProvider.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -10,24 +10,11 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
+  
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
-
   </ItemGroup>
+  
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\Snowflake.ruleset</CodeAnalysisRuleSet>
     <LangVersion>8.0</LangVersion>

--- a/src/Snowflake.Support.StoneProvider/Snowflake.Support.StoneProvider.csproj
+++ b/src/Snowflake.Support.StoneProvider/Snowflake.Support.StoneProvider.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -11,21 +11,6 @@
     <EmbeddedResource Include="..\..\stone\dist\stone.dist.json" Link="stone.dist.json" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <!-- The tools reference -->
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
-  
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
 

--- a/src/Snowflake.Support.StoreProviders/Snowflake.Support.StoreProviders.csproj
+++ b/src/Snowflake.Support.StoreProviders/Snowflake.Support.StoreProviders.csproj
@@ -1,29 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <AssemblyName>Snowflake.Support.StoreProviders</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
   
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
-
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Snowflake.Support.Windows.InputEnumerators/Snowflake.Support.Windows.InputEnumerators.csproj
+++ b/src/Snowflake.Support.Windows.InputEnumerators/Snowflake.Support.Windows.InputEnumerators.csproj
@@ -1,19 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>Snowflake</RootNamespace>
     <AssemblyName>Snowflake.Support.Windows.InputEnumerators</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Update="module.json">

--- a/src/Snowflake.Support.Windows.InputManager/Snowflake.Support.Windows.InputManager.csproj
+++ b/src/Snowflake.Support.Windows.InputManager/Snowflake.Support.Windows.InputManager.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -13,20 +13,9 @@
     <PackageReference Include="SharpDX.XInput" Version="4.2.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
-  </ItemGroup>
+  
 
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-snowflake" Version="1.5.1" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>

--- a/src/Snowflake.Support.Windows.InputManager/Snowflake.Support.Windows.InputManager.csproj
+++ b/src/Snowflake.Support.Windows.InputManager/Snowflake.Support.Windows.InputManager.csproj
@@ -13,8 +13,6 @@
     <PackageReference Include="SharpDX.XInput" Version="4.2.0" />
   </ItemGroup>
 
-  
-
 
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />

--- a/src/Snowflake.Templates.AssemblyModule/Snowflake.Templates.AssemblyModule.nuspec
+++ b/src/Snowflake.Templates.AssemblyModule/Snowflake.Templates.AssemblyModule.nuspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Snowflake.Templates.AssemblyModule</id>
+    <version>1.0.0</version>
+    <description>
+      Creates a Snowflake Module/Plugin
+    </description>
+    <authors>Snowflake Authors</authors>
+    <iconUrl>https://raw.githubusercontent.com/SnowflakePowered/snowflake/master/branding/horizon/snowflake/exports/Logo-Badge%40500px.png</iconUrl>
+    <packageTypes>
+      <packageType name="Template" />
+    </packageTypes>
+  </metadata>
+</package>

--- a/src/Snowflake.Templates.AssemblyModule/content/.template.config/template.json
+++ b/src/Snowflake.Templates.AssemblyModule/content/.template.config/template.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "Snowflake Authors",
+    "classifications": [ "Snowflake" ],
+    "identity": "Snowflake.Templates.AssemblyModule",
+    "name": "Snowflake Assembly Module/Plugin",
+    "shortName": "snowflake-mod",
+    "tags": {
+        "language": "C#"
+    },
+    "sourceName": "Snowflake.Templates.AssemblyModule", 
+    "preferNameDirectory" : true,
+    "symbols":{
+        "author": {
+            "type": "parameter",
+            "replaces":"$author",
+            "isRequired": true,
+            "description": "The author of this module."
+        },
+        "composablename": {
+            "type": "parameter",
+            "replaces":"$composablename",
+            "defaultValue": "My Composable",
+            "description": "The name of this module as it will appear to the user."
+        },
+        "loader": {
+            "type": "parameter",
+            "replaces":"$loader",
+            "defaultValue": "assembly",
+            "isRequired": false,
+            "description": "Overrides loader used to load this module. Although not recommended in favor of other solutions, may be used to create modules for custom loaders."
+        }
+    }
+}

--- a/src/Snowflake.Templates.AssemblyModule/content/Composable1.cs
+++ b/src/Snowflake.Templates.AssemblyModule/content/Composable1.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Snowflake.Loader;
+using Snowflake.Services;
+
+namespace Snowflake.Templates.AssemblyModule
+{
+    public class Composable1 : IComposable
+    {
+        [ImportService(typeof(ILogProvider))]
+        [ImportService(typeof(IServiceRegistrationProvider))]
+        public void Compose(IModule composableModule, IServiceRepository serviceContainer)
+        {
+            serviceContainer.Get<ILogProvider>()
+                .GetLogger(composableModule.Name)
+                .Info("Hello World!");
+        }
+    }
+}

--- a/src/Snowflake.Templates.AssemblyModule/content/Snowflake.Templates.AssemblyModule.csproj
+++ b/src/Snowflake.Templates.AssemblyModule/content/Snowflake.Templates.AssemblyModule.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
+  
 </Project>

--- a/src/Snowflake.Templates.AssemblyModule/content/module.json
+++ b/src/Snowflake.Templates.AssemblyModule/content/module.json
@@ -1,0 +1,8 @@
+﻿{
+  "entry": "Snowflake.Templates.AssemblyModule.dll",
+  "loader": "$loader",
+  "frameworkVersion": "1.0.0",
+  "version": "1.0.0",
+  "author": "$author",
+  "name": "$composablename"
+}

--- a/src/Snowflake.Tooling.HelloWorldContainer/Snowflake.Tooling.HelloWorldContainer.csproj
+++ b/src/Snowflake.Tooling.HelloWorldContainer/Snowflake.Tooling.HelloWorldContainer.csproj
@@ -8,8 +8,6 @@
     <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
   </ItemGroup>
 
-  
-
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>

--- a/src/Snowflake.Tooling.HelloWorldContainer/Snowflake.Tooling.HelloWorldContainer.csproj
+++ b/src/Snowflake.Tooling.HelloWorldContainer/Snowflake.Tooling.HelloWorldContainer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -8,11 +8,8 @@
     <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="module.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+  
+
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>

--- a/src/Snowflake.Tooling.Taskrunner/Snowflake.Tooling.Taskrunner.csproj
+++ b/src/Snowflake.Tooling.Taskrunner/Snowflake.Tooling.Taskrunner.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Snowflake.Tooling.Taskrunner</RootNamespace>
     <OutputType>Exe</OutputType>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.5.1</Version>
+    <Version>1.6.0</Version>
     <StartupObject />
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/src/Snowflake.Tooling.Taskrunner/Tasks/PackTask/AssemblyTreeShaker.cs
+++ b/src/Snowflake.Tooling.Taskrunner/Tasks/PackTask/AssemblyTreeShaker.cs
@@ -24,7 +24,7 @@ namespace Snowflake.Tooling.Taskrunner.Tasks.PackTask
 
             Console.WriteLine(dependencyContext.RuntimeGraph.Select(p => p.Runtime).Count());
             IEnumerable<Dependency> frameworkDependencies =
-                dependencyContext.RuntimeLibraries.Where(l => l.Name == "Snowflake.Framework")
+                dependencyContext.RuntimeLibraries.Where(l => l.Name.StartsWith("Snowflake.Framework"))
                     .SelectMany(l => l.Dependencies);
 
             var dependencyTree = this.ResolveDependencyTree(dependencyContext, frameworkDependencies);
@@ -33,7 +33,7 @@ namespace Snowflake.Tooling.Taskrunner.Tasks.PackTask
                 .SelectMany(p => p.NativeLibraryGroups)
                 .SelectMany(p => p.AssetPaths)
                 .Select(p => Path.GetFileName(p));
-            var frameworkDlls = dependencyContext.RuntimeLibraries.Where(l => l.Name == "Snowflake.Framework")
+            var frameworkDlls = dependencyContext.RuntimeLibraries.Where(l => l.Name.StartsWith("Snowflake.Framework"))
                 .Select(l => l.Name + ".dll");
             var dependencyDlls = dependencyTree.Select(d => d.Name + ".dll");
             return nativeDlls.Concat(dependencyDlls).Concat(frameworkDlls).Distinct().ToList();

--- a/src/Snowflake.Tooling.Taskrunner/Tasks/PackTask/AssemblyTreeShaker.cs
+++ b/src/Snowflake.Tooling.Taskrunner/Tasks/PackTask/AssemblyTreeShaker.cs
@@ -28,13 +28,17 @@ namespace Snowflake.Tooling.Taskrunner.Tasks.PackTask
                     .SelectMany(l => l.Dependencies);
 
             var dependencyTree = this.ResolveDependencyTree(dependencyContext, frameworkDependencies);
-            var nativeDlls = frameworkDependencies.Concat(dependencyTree).Distinct()
+
+            var nativeDlls = frameworkDependencies.Concat(dependencyTree)
+                
                 .Select(p => dependencyContext.RuntimeLibraries.FirstOrDefault(l => l.Name == p.Name))
                 .SelectMany(p => p.NativeLibraryGroups)
                 .SelectMany(p => p.AssetPaths)
                 .Select(p => Path.GetFileName(p));
+
             var frameworkDlls = dependencyContext.RuntimeLibraries.Where(l => l.Name.StartsWith("Snowflake.Framework"))
                 .Select(l => l.Name + ".dll");
+
             var dependencyDlls = dependencyTree.Select(d => d.Name + ".dll");
             return nativeDlls.Concat(dependencyDlls).Concat(frameworkDlls).Distinct().ToList();
         }

--- a/src/Snowflake.Tooling.Taskrunner/Tasks/PackTask/AssemblyTreeShaker.cs
+++ b/src/Snowflake.Tooling.Taskrunner/Tasks/PackTask/AssemblyTreeShaker.cs
@@ -28,17 +28,13 @@ namespace Snowflake.Tooling.Taskrunner.Tasks.PackTask
                     .SelectMany(l => l.Dependencies);
 
             var dependencyTree = this.ResolveDependencyTree(dependencyContext, frameworkDependencies);
-
-            var nativeDlls = frameworkDependencies.Concat(dependencyTree)
-                
+            var nativeDlls = frameworkDependencies.Concat(dependencyTree).Distinct()
                 .Select(p => dependencyContext.RuntimeLibraries.FirstOrDefault(l => l.Name == p.Name))
-                .SelectMany(p => p.NativeLibraryGroups)
+                .SelectMany(p => p.NativeLibraryGroups.Concat(p.RuntimeAssemblyGroups))
                 .SelectMany(p => p.AssetPaths)
                 .Select(p => Path.GetFileName(p));
-
             var frameworkDlls = dependencyContext.RuntimeLibraries.Where(l => l.Name.StartsWith("Snowflake.Framework"))
                 .Select(l => l.Name + ".dll");
-
             var dependencyDlls = dependencyTree.Select(d => d.Name + ".dll");
             return nativeDlls.Concat(dependencyDlls).Concat(frameworkDlls).Distinct().ToList();
         }

--- a/src/Snowflake.sln
+++ b/src/Snowflake.sln
@@ -37,8 +37,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snowflake.Tooling.HelloWorl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snowflake.Support.StoneProvider", "Snowflake.Support.StoneProvider\Snowflake.Support.StoneProvider.csproj", "{AD3E7BA2-4B2F-47FD-BA0C-DB4EF83BB05D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snowflake.Support.StoreProviders", "Snowflake.Support.StoreProviders\Snowflake.Support.StoreProviders.csproj", "{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snowflake.Support.PluginManager", "Snowflake.Support.PluginManager\Snowflake.Support.PluginManager.csproj", "{4CE3F6B7-4F87-454F-B590-85037D5BE085}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snowflake.Support.ShiragameProvider", "Snowflake.Support.ShiragameProvider\Snowflake.Support.ShiragameProvider.csproj", "{77C85584-ABF2-4750-BB85-8CE49EDC65FF}"
@@ -84,6 +82,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snowflake.Plugin.Debug.GraphQLVisualizers", "Snowflake.Plugin.Debug.GraphQLVisualizers\Snowflake.Plugin.Debug.GraphQLVisualizers.csproj", "{9AEF4D1D-2871-4CA6-AA33-E2A019E0CE0A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snowflake.Support.GraphQLFrameworkQueries", "Snowflake.Support.GraphQLFrameworkQueries\Snowflake.Support.GraphQLFrameworkQueries.csproj", "{81A053BD-9BFF-4BCC-99EE-2A5B742FD370}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snowflake.Support.StoreProviders", "Snowflake.Support.StoreProviders\Snowflake.Support.StoreProviders.csproj", "{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -227,18 +227,6 @@ Global
 		{AD3E7BA2-4B2F-47FD-BA0C-DB4EF83BB05D}.Release|x64.Build.0 = Release|Any CPU
 		{AD3E7BA2-4B2F-47FD-BA0C-DB4EF83BB05D}.Release|x86.ActiveCfg = Release|Any CPU
 		{AD3E7BA2-4B2F-47FD-BA0C-DB4EF83BB05D}.Release|x86.Build.0 = Release|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Debug|x64.Build.0 = Debug|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Debug|x86.Build.0 = Debug|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Release|x64.ActiveCfg = Release|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Release|x64.Build.0 = Release|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Release|x86.ActiveCfg = Release|Any CPU
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5}.Release|x86.Build.0 = Release|Any CPU
 		{4CE3F6B7-4F87-454F-B590-85037D5BE085}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4CE3F6B7-4F87-454F-B590-85037D5BE085}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4CE3F6B7-4F87-454F-B590-85037D5BE085}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -455,6 +443,18 @@ Global
 		{81A053BD-9BFF-4BCC-99EE-2A5B742FD370}.Release|x64.Build.0 = Release|Any CPU
 		{81A053BD-9BFF-4BCC-99EE-2A5B742FD370}.Release|x86.ActiveCfg = Release|Any CPU
 		{81A053BD-9BFF-4BCC-99EE-2A5B742FD370}.Release|x86.Build.0 = Release|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Debug|x64.Build.0 = Debug|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Debug|x86.Build.0 = Debug|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Release|x64.ActiveCfg = Release|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Release|x64.Build.0 = Release|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Release|x86.ActiveCfg = Release|Any CPU
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -472,7 +472,6 @@ Global
 		{5881A6EB-E702-4A4E-9F0A-6B4B91FE34B6} = {16BB0B43-6224-42C2-9A33-A039348CF965}
 		{292B1A29-4ADE-49CB-BDE3-20759AB20E37} = {8E178A6E-EAA5-413A-9EBE-36557DFF288E}
 		{AD3E7BA2-4B2F-47FD-BA0C-DB4EF83BB05D} = {FBD15674-246A-4C57-B865-07214D8BB9A1}
-		{01DDE186-5378-4C77-9CA1-3BC161F2B9E5} = {FBD15674-246A-4C57-B865-07214D8BB9A1}
 		{4CE3F6B7-4F87-454F-B590-85037D5BE085} = {FBD15674-246A-4C57-B865-07214D8BB9A1}
 		{77C85584-ABF2-4750-BB85-8CE49EDC65FF} = {FBD15674-246A-4C57-B865-07214D8BB9A1}
 		{28E6E924-BC59-4124-9EB1-F02A57C7A7E3} = {16BB0B43-6224-42C2-9A33-A039348CF965}
@@ -493,6 +492,7 @@ Global
 		{1E86524C-DF07-4BD1-92C6-843ABA8BE837} = {4D861CF0-7989-4E65-8F7C-B802B5D1AD86}
 		{9AEF4D1D-2871-4CA6-AA33-E2A019E0CE0A} = {1E86524C-DF07-4BD1-92C6-843ABA8BE837}
 		{81A053BD-9BFF-4BCC-99EE-2A5B742FD370} = {FBD15674-246A-4C57-B865-07214D8BB9A1}
+		{90F3AA90-3C48-4C01-9E4D-E58BA5E78AC7} = {FBD15674-246A-4C57-B865-07214D8BB9A1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {532F5D25-2D82-45B3-BF60-DDA40A0FB795}


### PR DESCRIPTION
This PR, along with several previous from the same branch, formalizes a custom MSBuild Project SDK for Snowflake composables. 

## .NET Custom SDK
A meta-package [Snowflake.Framework.Library](https://www.myget.org/feed/snowflake-nightly/package/nuget/Snowflake.Framework.Library), and an SDK package [Snowflake.Framework.Sdk](https://www.myget.org/feed/snowflake-nightly/package/nuget/Snowflake.Framework.Sdk) has been created to consolidate the required *Snowflake.Framework.\** packages and dependencies.

As a result, the .NET CLI Tool `dotnet snowflake` can now pack leaner assemblies that tree shake the entire tree of dependencies leading from *Snowflake.Framework.\**. This allows us to take on heavier dependencies for the framework without having to use indirection through interfaces, and completely removes any duplication of assemblies.

The custom SDK will also copy module.json if present in the directory automatically to its proper position, and includes *dotnet-snowflake* as a `DotNetCliToolReference`.

## .NET CLI Template

This brings support for `dotnet new` to easily get started with Snowflake composables and the latest SDK.

```bash
$ dotnet new -i Snowflake.Templates.AssemblyModule
$ dotnet new snowflake-mod --author "John Doe"
```

Note that this will require using the nightly MyGet feed for now with a NuGet.config. This will change in the future, since SDKs only support SemVer 1.0, and the current SDK reference points directly to the latest master build.

```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
    <packageSources>
        <add key="myget-snowflake" value="https://www.myget.org/F/snowflake-nightly/api/v3/index.json" />
    </packageSources>
</configuration>
```

Due to these two changes, `dotnet new snowflake-mod` is now the **only supported way** to create Snowflake modules, as it will ensure that there are no conflicting assemblies. In addition to the core Snowflake framework assemblies, the following NuGet packages are also available as part of the Snowflake framework

* Newtonsoft.Json
* System.Collections.Immutable
* System.Dynamic.Runtime
* System.Linq.Parallel
* Zio
* Microsoft.Data.Sqlite
* Microsoft.AspNetCore.Server.Kestrel
* GraphQL

Any installations of such assemblies will be tree-shaken by the assembly module packer and not included as part of the package, regardless of version. Avoid upgrading such packages directly through NuGet.