### PR TITLE
Update supported TFM to netcoreapp3.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,19 +19,6 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-  # - task: DotNetCoreInstaller@0
-  #   displayName: Installing .NET Core 3 SDK
-  #   inputs:
-  #     packageType: 'sdk' # Options: runtime, sdk
-  #     version: '3.0.100-preview3-010431' 
-  # - bash: |
-  #    wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
-  #    sudo dpkg -i packages-microsoft-prod.deb
-  #    sudo apt-get install apt-transport-https
-  #    sudo apt-get update
-  #    sudo apt-get install dotnet-sdk-2.2
-  #    sudo apt-get install dotnet-sdk-2.1
-  #   displayName: Manually install .NET Core 2.2 SDK
   - template: azure-setup.yml  # Template referenc
     parameters:
       os: Linux

--- a/azure-setup.yml
+++ b/azure-setup.yml
@@ -21,6 +21,7 @@ steps:
     lfs: false
 
   - script: |
+      nuget locals all -clear
       dotnet run --project build -- ContinuousIntegration
     displayName: Build and package framework and modules.
 

--- a/build/Snowflake.Tooling.BuildScript.csproj
+++ b/build/Snowflake.Tooling.BuildScript.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace></RootNamespace>
     <IsPackable>False</IsPackable>

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -8,7 +8,7 @@ extraction:
       solution: src/Snowflake.sln
       vstools_version: 15
       dotnet:
-        version: 3.0.100-preview-009812
+        version: 3.0.100-preview3-010431
   python:
     python_setup: 
       version: 3

--- a/src/Snowflake.Bootstrap.Windows/Snowflake.Bootstrap.Windows.csproj
+++ b/src/Snowflake.Bootstrap.Windows/Snowflake.Bootstrap.Windows.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;win10-x64;</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/src/Snowflake.Framework.Library/Snowflake.Framework.Library.csproj
+++ b/src/Snowflake.Framework.Library/Snowflake.Framework.Library.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <_SnowflakeSDKDependenciesVersion>1.0.1</_SnowflakeSDKDependenciesVersion>
     <_SnowflakeSDKAssembliesVersion>1.0.0-alpha.*</_SnowflakeSDKAssembliesVersion>

--- a/src/Snowflake.Framework.Persistence/Snowflake.Framework.Persistence.csproj
+++ b/src/Snowflake.Framework.Persistence/Snowflake.Framework.Persistence.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Dependencies.Sdk/2.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 

--- a/src/Snowflake.Framework.Remoting/Snowflake.Framework.Remoting.csproj
+++ b/src/Snowflake.Framework.Remoting/Snowflake.Framework.Remoting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Dependencies.Sdk/2.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Snowflake.Framework.Sdk/Sdk/Sdk.props
+++ b/src/Snowflake.Framework.Sdk/Sdk/Sdk.props
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <_SnowflakeUseDevelopmentSDK>false</_SnowflakeUseDevelopmentSDK>
     <SnowflakeSDKAssembliesVersion>1.0.0-alpha.*</SnowflakeSDKAssembliesVersion>
-    <SnowflakeSDKToolingVersion>1.6.0</SnowflakeSDKToolingVersion>
+    <SnowflakeSDKToolingVersion>2.0.0</SnowflakeSDKToolingVersion>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(_SnowflakeUseDevelopmentSDK)' == 'false' ">

--- a/src/Snowflake.Framework.Sdk/Sdk/Sdk.targets
+++ b/src/Snowflake.Framework.Sdk/Sdk/Sdk.targets
@@ -3,8 +3,8 @@
  
   <Target Name="EnsureTFMCompatibility" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
     <Error
-      Text="This version of Snowflake.Framework.Library is only compatible with the netcoreapp2.2 target framework. Please target netcoreapp2.2."
-      Condition="'$(TargetFramework)' != 'netcoreapp2.2'"/>
+      Text="This version of Snowflake.Framework.Library is only compatible with the netcoreapp3.0 target framework. Please target netcoreapp3.0."
+      Condition="'$(TargetFramework)' != 'netcoreapp3.0'"/>
   </Target>
 
 </Project>

--- a/src/Snowflake.Framework.Sdk/Snowflake.Framework.Sdk.csproj
+++ b/src/Snowflake.Framework.Sdk/Snowflake.Framework.Sdk.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <Version>1.0.0</Version>
+    <Version>2.0.0</Version>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
     <PackageTags>snowflake</PackageTags>

--- a/src/Snowflake.Framework.Sdk/Snowflake.Framework.Sdk.csproj
+++ b/src/Snowflake.Framework.Sdk/Snowflake.Framework.Sdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Version>1.0.0</Version>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Snowflake.Framework.Sdk/Snowflake.Framework.Sdk.nuspec
+++ b/src/Snowflake.Framework.Sdk/Snowflake.Framework.Sdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Snowflake.Framework.Sdk</id>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
     <authors>Snowflake Developers</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MPL-2.0</license>

--- a/src/Snowflake.Framework.Services/Snowflake.Framework.Services.csproj
+++ b/src/Snowflake.Framework.Services/Snowflake.Framework.Services.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Snowflake.Framework.Dependencies.Sdk/2.0.0">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>    <RootNamespace>Snowflake</RootNamespace>
+    <TargetFramework>netcoreapp3.0</TargetFramework>    <RootNamespace>Snowflake</RootNamespace>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 

--- a/src/Snowflake.Framework.Tests.DummyComposable/Snowflake.Framework.Tests.DummyComposable.csproj
+++ b/src/Snowflake.Framework.Tests.DummyComposable/Snowflake.Framework.Tests.DummyComposable.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Snowflake.Framework.Tests.DummyComposable/Snowflake.Framework.Tests.DummyComposable.csproj
+++ b/src/Snowflake.Framework.Tests.DummyComposable/Snowflake.Framework.Tests.DummyComposable.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Framework.Tests.DummyComposableInterface/Snowflake.Framework.Tests.DummyComposableInterface.csproj
+++ b/src/Snowflake.Framework.Tests.DummyComposableInterface/Snowflake.Framework.Tests.DummyComposableInterface.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />

--- a/src/Snowflake.Framework.Tests.DummyComposableInterface/Snowflake.Framework.Tests.DummyComposableInterface.csproj
+++ b/src/Snowflake.Framework.Tests.DummyComposableInterface/Snowflake.Framework.Tests.DummyComposableInterface.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Framework.Tests.InvalidComposable/Snowflake.Framework.Tests.InvalidComposable.csproj
+++ b/src/Snowflake.Framework.Tests.InvalidComposable/Snowflake.Framework.Tests.InvalidComposable.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Framework.Tests.InvalidComposable/Snowflake.Framework.Tests.InvalidComposable.csproj
+++ b/src/Snowflake.Framework.Tests.InvalidComposable/Snowflake.Framework.Tests.InvalidComposable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Snowflake.Framework.Tests/Snowflake.Framework.Tests.csproj
+++ b/src/Snowflake.Framework.Tests/Snowflake.Framework.Tests.csproj
@@ -77,7 +77,7 @@
   <PropertyGroup>
     <CoverletOutputFormat>opencover,cobertura</CoverletOutputFormat>
     <Include>[Snowflake.Framework*]*,[Snowflake.Support*]*,[Snowflake.Support.*]*</Include>
-    <Exclude>[Snowflake.Framework.Tests*]*,[Snowflake.Support.FileSignatures]*</Exclude>
+    <Exclude>[Snowflake.Framework.Tests]*,[Snowflake.Support.FileSignatures]*</Exclude>
     <CollectCoverage>true</CollectCoverage>
   </PropertyGroup>
 </Project>

--- a/src/Snowflake.Framework.Tests/Snowflake.Framework.Tests.csproj
+++ b/src/Snowflake.Framework.Tests/Snowflake.Framework.Tests.csproj
@@ -76,7 +76,7 @@
 
   <PropertyGroup>
     <CoverletOutputFormat>opencover,cobertura</CoverletOutputFormat>
-    <Include>[Snowflake.Framework*]*,[Snowflake.Support*]*</Include>
+    <Include>[Snowflake.Framework*]*,[Snowflake.Support*]*,[Snowflake.Support.*]*</Include>
     <Exclude>[Snowflake.Framework.Tests*]*,[Snowflake.Support.FileSignatures]*</Exclude>
     <CollectCoverage>true</CollectCoverage>
   </PropertyGroup>

--- a/src/Snowflake.Framework.Tests/Snowflake.Framework.Tests.csproj
+++ b/src/Snowflake.Framework.Tests/Snowflake.Framework.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Snowflake</RootNamespace>
   </PropertyGroup>
 

--- a/src/Snowflake.Framework/Snowflake.Framework.csproj
+++ b/src/Snowflake.Framework/Snowflake.Framework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Dependencies.Sdk/2.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework> 
+    <TargetFramework>netcoreapp3.0</TargetFramework> 
     <RootNamespace>Snowflake</RootNamespace>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <LangVersion>8.0</LangVersion>

--- a/src/Snowflake.Plugin.Debug.GraphQLVisualizers/Snowflake.Plugin.Debug.GraphQLVisualizers.csproj
+++ b/src/Snowflake.Plugin.Debug.GraphQLVisualizers/Snowflake.Plugin.Debug.GraphQLVisualizers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Plugin.Debug.GraphQLVisualizers/Snowflake.Plugin.Debug.GraphQLVisualizers.csproj
+++ b/src/Snowflake.Plugin.Debug.GraphQLVisualizers/Snowflake.Plugin.Debug.GraphQLVisualizers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 

--- a/src/Snowflake.Plugin.Emulators.RetroArch/Snowflake.Plugin.Emulators.RetroArch.csproj
+++ b/src/Snowflake.Plugin.Emulators.RetroArch/Snowflake.Plugin.Emulators.RetroArch.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Plugin.Emulators.RetroArch/Snowflake.Plugin.Emulators.RetroArch.csproj
+++ b/src/Snowflake.Plugin.Emulators.RetroArch/Snowflake.Plugin.Emulators.RetroArch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Snowflake</RootNamespace>
   </PropertyGroup>
 

--- a/src/Snowflake.Plugin.Scraping.FileSignatures/Snowflake.Plugin.Scraping.FileSignatures.csproj
+++ b/src/Snowflake.Plugin.Scraping.FileSignatures/Snowflake.Plugin.Scraping.FileSignatures.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Plugin.Scraping.FileSignatures/Snowflake.Plugin.Scraping.FileSignatures.csproj
+++ b/src/Snowflake.Plugin.Scraping.FileSignatures/Snowflake.Plugin.Scraping.FileSignatures.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Snowflake.Plugin.Scraping.FileSignatures</RootNamespace>
     <AssemblyName>Snowflake.Plugin.Scraping.FileSignatures</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>

--- a/src/Snowflake.Plugin.Scraping.TheGamesDb/Snowflake.Plugin.Scraping.TheGamesDb.csproj
+++ b/src/Snowflake.Plugin.Scraping.TheGamesDb/Snowflake.Plugin.Scraping.TheGamesDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   

--- a/src/Snowflake.Plugin.Scraping.TheGamesDb/Snowflake.Plugin.Scraping.TheGamesDb.csproj
+++ b/src/Snowflake.Plugin.Scraping.TheGamesDb/Snowflake.Plugin.Scraping.TheGamesDb.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Support.Execution.Providers/Snowflake.Support.Execution.Providers.csproj
+++ b/src/Snowflake.Support.Execution.Providers/Snowflake.Support.Execution.Providers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/Snowflake.Support.Execution.Providers/Snowflake.Support.Execution.Providers.csproj
+++ b/src/Snowflake.Support.Execution.Providers/Snowflake.Support.Execution.Providers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Snowflake.Support.GraphQLFrameworkQueries.csproj
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Snowflake.Support.GraphQLFrameworkQueries.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Snowflake.Support.GraphQLFrameworkQueries.csproj
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Snowflake.Support.GraphQLFrameworkQueries.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 

--- a/src/Snowflake.Support.PluginManager/Snowflake.Support.PluginManager.csproj
+++ b/src/Snowflake.Support.PluginManager/Snowflake.Support.PluginManager.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Support.PluginManager/Snowflake.Support.PluginManager.csproj
+++ b/src/Snowflake.Support.PluginManager/Snowflake.Support.PluginManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>Snowflake.Support.PluginManager</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Snowflake.Support.Remoting.Electron.ThemeProvider/Snowflake.Support.Remoting.Electron.ThemeProvider.csproj
+++ b/src/Snowflake.Support.Remoting.Electron.ThemeProvider/Snowflake.Support.Remoting.Electron.ThemeProvider.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Support.Remoting.Electron.ThemeProvider/Snowflake.Support.Remoting.Electron.ThemeProvider.csproj
+++ b/src/Snowflake.Support.Remoting.Electron.ThemeProvider/Snowflake.Support.Remoting.Electron.ThemeProvider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Snowflake.Support.Scraping.RecordScrapeEngine/Snowflake.Support.Scraping.RecordScrapeEngine.csproj
+++ b/src/Snowflake.Support.Scraping.RecordScrapeEngine/Snowflake.Support.Scraping.RecordScrapeEngine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Snowflake.Support.Scraping.RecordScrapeEngine/Snowflake.Support.Scraping.RecordScrapeEngine.csproj
+++ b/src/Snowflake.Support.Scraping.RecordScrapeEngine/Snowflake.Support.Scraping.RecordScrapeEngine.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Support.Scraping.RecordTraversers/Snowflake.Support.Scraping.RecordTraversers.csproj
+++ b/src/Snowflake.Support.Scraping.RecordTraversers/Snowflake.Support.Scraping.RecordTraversers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Snowflake.Support.Scraping.RecordTraversers/Snowflake.Support.Scraping.RecordTraversers.csproj
+++ b/src/Snowflake.Support.Scraping.RecordTraversers/Snowflake.Support.Scraping.RecordTraversers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Support.ShiragameProvider/Snowflake.Support.ShiragameProvider.csproj
+++ b/src/Snowflake.Support.ShiragameProvider/Snowflake.Support.ShiragameProvider.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Support.ShiragameProvider/Snowflake.Support.ShiragameProvider.csproj
+++ b/src/Snowflake.Support.ShiragameProvider/Snowflake.Support.ShiragameProvider.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 

--- a/src/Snowflake.Support.StoneProvider/Snowflake.Support.StoneProvider.csproj
+++ b/src/Snowflake.Support.StoneProvider/Snowflake.Support.StoneProvider.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Support.StoneProvider/Snowflake.Support.StoneProvider.csproj
+++ b/src/Snowflake.Support.StoneProvider/Snowflake.Support.StoneProvider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Snowflake</RootNamespace>
     <AssemblyName>Snowflake.Support.StoneProvider</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>

--- a/src/Snowflake.Support.StoreProviders/Snowflake.Support.StoreProviders.csproj
+++ b/src/Snowflake.Support.StoreProviders/Snowflake.Support.StoreProviders.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Support.StoreProviders/Snowflake.Support.StoreProviders.csproj
+++ b/src/Snowflake.Support.StoreProviders/Snowflake.Support.StoreProviders.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>Snowflake.Support.StoreProviders</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Snowflake.Support.Windows.InputEnumerators/Snowflake.Support.Windows.InputEnumerators.csproj
+++ b/src/Snowflake.Support.Windows.InputEnumerators/Snowflake.Support.Windows.InputEnumerators.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Snowflake</RootNamespace>
     <AssemblyName>Snowflake.Support.Windows.InputEnumerators</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>

--- a/src/Snowflake.Support.Windows.InputEnumerators/Snowflake.Support.Windows.InputEnumerators.csproj
+++ b/src/Snowflake.Support.Windows.InputEnumerators/Snowflake.Support.Windows.InputEnumerators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Snowflake</RootNamespace>

--- a/src/Snowflake.Support.Windows.InputManager/Snowflake.Support.Windows.InputManager.csproj
+++ b/src/Snowflake.Support.Windows.InputManager/Snowflake.Support.Windows.InputManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Snowflake</RootNamespace>
     <AssemblyName>Snowflake.Support.Windows.InputManager</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>

--- a/src/Snowflake.Support.Windows.InputManager/Snowflake.Support.Windows.InputManager.csproj
+++ b/src/Snowflake.Support.Windows.InputManager/Snowflake.Support.Windows.InputManager.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Templates.AssemblyModule/content/Snowflake.Templates.AssemblyModule.csproj
+++ b/src/Snowflake.Templates.AssemblyModule/content/Snowflake.Templates.AssemblyModule.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk/2.0.0">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>

--- a/src/Snowflake.Templates.AssemblyModule/content/Snowflake.Templates.AssemblyModule.csproj
+++ b/src/Snowflake.Templates.AssemblyModule/content/Snowflake.Templates.AssemblyModule.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   
 </Project>

--- a/src/Snowflake.Tooling.HelloWorldContainer/Snowflake.Tooling.HelloWorldContainer.csproj
+++ b/src/Snowflake.Tooling.HelloWorldContainer/Snowflake.Tooling.HelloWorldContainer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
+﻿<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Snowflake.Tooling.HelloWorldContainer/Snowflake.Tooling.HelloWorldContainer.csproj
+++ b/src/Snowflake.Tooling.HelloWorldContainer/Snowflake.Tooling.HelloWorldContainer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Snowflake.Framework.Sdk/1.0.0">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Snowflake.Tooling.Shiragame/Snowflake.Tooling.Shiragame.csproj
+++ b/src/Snowflake.Tooling.Shiragame/Snowflake.Tooling.Shiragame.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Snowflake.Tooling.Taskrunner/Snowflake.Tooling.Taskrunner.csproj
+++ b/src/Snowflake.Tooling.Taskrunner/Snowflake.Tooling.Taskrunner.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Snowflake.Tooling.Taskrunner</RootNamespace>
     <OutputType>Exe</OutputType>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.6.0</Version>
+    <Version>2.0.0</Version>
     <StartupObject />
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/src/Snowflake.Tooling.Taskrunner/Snowflake.Tooling.Taskrunner.csproj
+++ b/src/Snowflake.Tooling.Taskrunner/Snowflake.Tooling.Taskrunner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>dotnet-snowflake</AssemblyName>
     <RootNamespace>Snowflake.Tooling.Taskrunner</RootNamespace>
     <OutputType>Exe</OutputType>

--- a/src/Snowflake.Tooling.Taskrunner/Tasks/AssemblyModuleBuilderTask/AssemblyModuleBuilderTaskRunner.cs
+++ b/src/Snowflake.Tooling.Taskrunner/Tasks/AssemblyModuleBuilderTask/AssemblyModuleBuilderTaskRunner.cs
@@ -71,9 +71,9 @@ namespace Snowflake.Tooling.Taskrunner.Tasks.AssemblyModuleBuilderTask
                 where element.Name.LocalName == "TargetFramework"
                 select element.Value).FirstOrDefault();
 
-            if (targetFramework != "netcoreapp2.2")
+            if (targetFramework != "netcoreapp3.0")
             {
-                throw new InvalidOperationException($"Error! Assembly modules must target framework netcoreapp2.2");
+                throw new InvalidOperationException($"Error! Assembly modules must target framework netcoreapp3.0");
             }
 
             Console.WriteLine($"Found module {module.Entry}");

--- a/src/global.json
+++ b/src/global.json
@@ -4,6 +4,6 @@
   },
   "msbuild-sdks": {
     "Snowflake.Framework.Dependencies.Sdk": "2.0.0",
-    "Snowflake.Framework.Sdk": "1.0.0"
+    "Snowflake.Framework.Sdk": "2.0.0"
   }
 }


### PR DESCRIPTION
This updates the supported TargetFramework from `netcoreapp2.2` to `netcoreapp3.0` as a future-proofing measure. 

The relevant backend tooling has already been updated to reflect this change. 

New version numbers for 
  * `dotnet-snowflake` 2.0.0
  * `Snowflake.Framework.Sdk` 2.0.0