### PR TITLE
Build: make changes to support .NET Core 3.0-preview6

### DIFF
--- a/azure-pack.yml
+++ b/azure-pack.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
       includePreviewVersions: true
       packageType: 'sdk' # Options: runtime, sdk
-      version: '3.0.100-preview5-011568'
+      version: '3.0.100-preview6-012264'
 
   - task: NuGetToolInstaller@0
     displayName: Installing NuGet CLI

--- a/azure-setup.yml
+++ b/azure-setup.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
       includePreviewVersions: true
       packageType: 'sdk' # Options: runtime, sdk
-      version: '3.0.100-preview5-011568' 
+      version: '3.0.100-preview6-012264'
 
   - task: NuGetToolInstaller@0
     displayName: Installing NuGet CLI

--- a/azure-test.yml
+++ b/azure-test.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
       includePreviewVersions: true
       packageType: 'sdk' # Options: runtime, sdk
-      version: '3.0.100-preview5-011568'
+      version: '3.0.100-preview6-012264'
 
   - task: NuGetToolInstaller@0
     displayName: Installing NuGet CLI

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -8,7 +8,7 @@ extraction:
       solution: src/Snowflake.sln
       vstools_version: 15
       dotnet:
-        version: 3.0.100-preview5-011568
+        version: 3.0.100-preview6-012264
   python:
     python_setup: 
       version: 3

--- a/src/Snowflake.Framework.Primitives/Model/Game/IGame.cs
+++ b/src/Snowflake.Framework.Primitives/Model/Game/IGame.cs
@@ -24,6 +24,6 @@ namespace Snowflake.Model.Game
         /// </summary>
         /// <typeparam name="TExtension">The type of the extension.</typeparam>
         /// <returns>The extension instance.</returns>
-        TExtension? GetExtension<TExtension>() where TExtension : class, IGameExtension;
+        TExtension GetExtension<TExtension>() where TExtension : class, IGameExtension;
     }
 }

--- a/src/Snowflake.Framework.Primitives/Model/Game/IGameLibrary.cs
+++ b/src/Snowflake.Framework.Primitives/Model/Game/IGameLibrary.cs
@@ -46,7 +46,7 @@ namespace Snowflake.Model.Game
         /// </summary>
         /// <typeparam name="T">The type of the extension provider.</typeparam>
         /// <returns>The regsitered instance of the requested extension provider. </returns>
-        T? GetExtension<T>() where T : class, IGameExtensionProvider;
+        T GetExtension<T>() where T : class, IGameExtensionProvider;
 
         /// <summary>
         /// Gets a game that was created in the library by its unique GUID.

--- a/src/Snowflake.Framework.Tests/Model/GameLibraryIntegrationTests.cs
+++ b/src/Snowflake.Framework.Tests/Model/GameLibraryIntegrationTests.cs
@@ -73,6 +73,25 @@ namespace Snowflake.Model.Tests
         }
 
         [Fact]
+        public void GameLibraryUnknownExtension_Test()
+        {
+            var path = new DirectoryInfo(Path.GetTempPath())
+                .CreateSubdirectory(Path.GetFileNameWithoutExtension(Path.GetTempFileName()));
+            var fs = new PhysicalFileSystem();
+            var gfs = fs.GetOrCreateSubFileSystem(fs.ConvertPathFromInternal(path.FullName));
+
+            var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>();
+            optionsBuilder.UseSqlite($"Data Source={Path.GetTempFileName()}");
+            var glib = new GameRecordLibrary(optionsBuilder);
+            var ccs = new ConfigurationCollectionStore(optionsBuilder);
+
+            var gl = new GameLibrary(glib);
+            Assert.Throws<KeyNotFoundException>(() => gl.GetExtension<IGameConfigurationExtensionProvider>());
+            var game = gl.CreateGame("NINTENDO_NES");
+            Assert.Throws<KeyNotFoundException>(() => game.GetExtension<IGameConfigurationExtension>());
+        }
+
+        [Fact]
         public void GameLibraryIntegrationUpdate_Test()
         {
             var path = new DirectoryInfo(Path.GetTempPath())

--- a/src/Snowflake.Framework/Model/Game/Game.cs
+++ b/src/Snowflake.Framework/Model/Game/Game.cs
@@ -24,8 +24,11 @@ namespace Snowflake.Model.Game
 
         public TExtension GetExtension<TExtension>() where TExtension : class, IGameExtension
         {
-            this.Extensions.TryGetValue(typeof(TExtension), out IGameExtension t);
-            return t as TExtension;
+            if (this.Extensions.TryGetValue(typeof(TExtension), out IGameExtension t))
+            {
+                return (TExtension)t;
+            }
+            throw new KeyNotFoundException($"Unable to find extension of type {typeof(TExtension).Name}");
         }
     }
 }

--- a/src/Snowflake.Framework/Model/Game/Game.cs
+++ b/src/Snowflake.Framework/Model/Game/Game.cs
@@ -22,7 +22,7 @@ namespace Snowflake.Model.Game
             this.Extensions = extensions;
         }
 
-        public TExtension? GetExtension<TExtension>() where TExtension : class, IGameExtension
+        public TExtension GetExtension<TExtension>() where TExtension : class, IGameExtension
         {
             this.Extensions.TryGetValue(typeof(TExtension), out IGameExtension t);
             return t as TExtension;

--- a/src/Snowflake.Framework/Model/Game/GameLibrary.cs
+++ b/src/Snowflake.Framework/Model/Game/GameLibrary.cs
@@ -33,7 +33,7 @@ namespace Snowflake.Model.Game
             this.Extensions.Add(typeof(TExtensionMaker), (typeof(TExtension), extension));
         }
 
-        public T? GetExtension<T>()
+        public T GetExtension<T>()
             where T : class, IGameExtensionProvider
         {
             return this.Extensions[typeof(T)].extension as T;

--- a/src/Snowflake.Framework/Model/Game/GameLibrary.cs
+++ b/src/Snowflake.Framework/Model/Game/GameLibrary.cs
@@ -36,7 +36,11 @@ namespace Snowflake.Model.Game
         public T GetExtension<T>()
             where T : class, IGameExtensionProvider
         {
-            return this.Extensions[typeof(T)].extension as T;
+            if (this.Extensions.TryGetValue(typeof(T), out var ext))
+            {
+                return (T)ext.extension;
+            }
+            throw new KeyNotFoundException($"Unable to find extension of type {typeof(T).Name}");
         }
 
         private GameRecordLibrary GameRecordLibrary { get; }

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100-preview5-011568"
+    "version": "3.0.100-preview6-012264"
   },
   "msbuild-sdks": {
     "Snowflake.Framework.Dependencies.Sdk": "2.0.0",


### PR DESCRIPTION
For some reason it doesn't like the signature `T? Fn<T>() where T: class, IInterface` anymore, so nullable refs for those have been removed.