### PR TITLE
deps: update deps to support .net core 3

### DIFF
--- a/azure-pack.yml
+++ b/azure-pack.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
       includePreviewVersions: true
       packageType: 'sdk' # Options: runtime, sdk
-      version: '3.0.100-preview7-012821'
+      version: '3.0.100'
 
   - task: NuGetToolInstaller@0
     displayName: Installing NuGet CLI

--- a/azure-setup.yml
+++ b/azure-setup.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
       includePreviewVersions: true
       packageType: 'sdk' # Options: runtime, sdk
-      version: '3.0.100-preview7-012821'
+      version: '3.0.100'
 
   - task: NuGetToolInstaller@0
     displayName: Installing NuGet CLI

--- a/azure-test.yml
+++ b/azure-test.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
       includePreviewVersions: true
       packageType: 'sdk' # Options: runtime, sdk
-      version: '3.0.100-preview7-012821'
+      version: '3.0.100'
 
   - task: NuGetToolInstaller@0
     displayName: Installing NuGet CLI

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -145,7 +145,7 @@ class Build : NukeBuild
     
     static string GetBuildNumber()
     {
-        string buildNumber = EnvironmentInfo.Variable("BUILD_NUMBER");
+        string buildNumber = EnvironmentInfo.GetVariable<string>("BUILD_NUMBER");
         if (String.IsNullOrWhiteSpace(buildNumber))
         {
             return "dirty";
@@ -155,7 +155,7 @@ class Build : NukeBuild
 
     static AbsolutePath GetOutDirectory()
     {
-        string staging = EnvironmentInfo.Variable("STAGING");
+        string staging = EnvironmentInfo.GetVariable<string>("STAGING");
         if (String.IsNullOrWhiteSpace(staging))
         {
             return RootDirectory / "out";

--- a/build/Snowflake.Tooling.BuildScript.csproj
+++ b/build/Snowflake.Tooling.BuildScript.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="16.0.461" />
-    <PackageReference Include="Nuke.Common" Version="0.20.1" />
+    <PackageReference Include="Nuke.Common" Version="0.22.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -8,7 +8,7 @@ extraction:
       solution: src/Snowflake.sln
       vstools_version: 15
       dotnet:
-        version: 3.0.100-preview7-012821
+        version: '3.0.100'
   python:
     python_setup: 
       version: 3

--- a/src/Snowflake.Framework.Dependencies/Snowflake.Framework.Dependencies.csproj
+++ b/src/Snowflake.Framework.Dependencies/Snowflake.Framework.Dependencies.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" Publish="True" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" Publish="True" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.6.0" Publish="True" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" Publish="True" />
     <PackageReference Include="System.Linq.Parallel" Version="4.3.0" Publish="True" />
-    <PackageReference Include="System.Reactive" Version="4.1.5" />
+    <PackageReference Include="System.Reactive" Version="4.1.6" />
   </ItemGroup>
 </Project>

--- a/src/Snowflake.Framework.Primitives/Input/Controller/ControllerId.cs
+++ b/src/Snowflake.Framework.Primitives/Input/Controller/ControllerId.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -8,7 +9,7 @@ namespace Snowflake.Input.Controller
     /// <summary>
     /// Represents a Stone controller ID.
     /// </summary>
-    public struct ControllerId : IEquatable<ControllerId>, IEquatable<string>
+    public struct ControllerId : IEquatable<ControllerId>, IEquatable<string>, IComparable<string>, IComparable
     {
         private string ControllerIdString { get; }
 
@@ -54,15 +55,21 @@ namespace Snowflake.Input.Controller
         {
             return HashCode.Combine(ControllerIdString);
         }
-        
+
+        public int CompareTo([AllowNull] string other)
+        {
+            return ControllerIdString.CompareTo(other);
+        }
+
+        public int CompareTo(object? obj)
+        {
+            if (obj is ControllerId c) return ControllerIdString.CompareTo(c.ControllerIdString);
+            return ControllerIdString.CompareTo(obj);
+        }
+
 #pragma warning disable 1591
         public static bool operator ==(ControllerId x, ControllerId y) => x.ControllerIdString == y.ControllerIdString;
         public static bool operator !=(ControllerId x, ControllerId y) => x.ControllerIdString != y.ControllerIdString;
-
-        public static bool operator ==(string x, ControllerId y) => x.ToUpperInvariant() == y.ControllerIdString;
-        public static bool operator !=(string x, ControllerId y) => x.ToUpperInvariant() != y.ControllerIdString;
-        public static bool operator ==(ControllerId x, string y) => x.ControllerIdString == y.ToUpperInvariant();
-        public static bool operator !=(ControllerId x, string y) => x.ControllerIdString != y.ToUpperInvariant();
 #pragma warning restore 1591
 
         

--- a/src/Snowflake.Framework.Primitives/Model/Game/IGameLibrary.cs
+++ b/src/Snowflake.Framework.Primitives/Model/Game/IGameLibrary.cs
@@ -64,21 +64,30 @@ namespace Snowflake.Model.Game
 
         /// <summary>
         /// Retrieves all games in the library that fulfill the provided predicate. The default implementation
-        /// executes this predicate on the database rather than in client code, thus is much faster than 
-        /// using <see cref="GetAllGames"/>.
+        /// executes this predicate in client code. Use <see cref="QueryGames(Expression{Func{IGameRecordQuery, bool}})"/>
+        /// instead if possible for more performant queries.
         /// </summary>
         /// <param name="predicate">The predicate to filter on.</param>
         /// <returns>All games in the library that fulfill the provided predicate.</returns>
         IEnumerable<IGame> GetGames(Expression<Func<IGameRecord, bool>> predicate);
 
         /// <summary>
-        /// Retrieves all games in the library that fulfill the provided predicate asynchronously. The default implementation
-        /// executes this predicate on the database rather than in client code, thus is much faster than 
-        /// using <see cref="GetAllGames"/>.
+        /// Retrieves all games in the library that fulfill the provided predicate. The default implementation
+        /// executes the predicate on the database than in client code, thus is much faster than 
+        /// using <see cref="GetAllGames"/> or <see cref="GetGames(Expression{Func{IGameRecord, bool}})"/>.
         /// </summary>
         /// <param name="predicate">The predicate to filter on.</param>
         /// <returns>All games in the library that fulfill the provided predicate.</returns>
-        Task<IEnumerable<IGame>> GetGamesAsync(Expression<Func<IGameRecord, bool>> predicate);
+        IEnumerable<IGame> QueryGames(Expression<Func<IGameRecordQuery, bool>> predicate);
+
+        /// <summary>
+        /// Retrieves all games in the library that fulfill the provided predicate asynchronously. The default implementation
+        /// executes this predicate on the database rather than in client code, thus is much faster than 
+        /// using <see cref="GetAllGames"/> or <see cref="GetGames(Expression{Func{IGameRecord, bool}})"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to filter on.</param>
+        /// <returns>All games in the library that fulfill the provided predicate.</returns>
+        Task<IEnumerable<IGame>> QueryGamesAsync(Expression<Func<IGameRecordQuery, bool>> predicate);
 
         /// <summary>
         /// Updates a <see cref="IGameRecord"/> that exists in the database by providing the changed <see cref="IGameRecord"/>.

--- a/src/Snowflake.Framework.Primitives/Model/Game/PlatformId.cs
+++ b/src/Snowflake.Framework.Primitives/Model/Game/PlatformId.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 
 namespace Snowflake.Model.Game
@@ -7,7 +10,7 @@ namespace Snowflake.Model.Game
     /// <summary>
     /// Represents a Stone Platform ID.
     /// </summary>
-    public struct PlatformId : IEquatable<PlatformId>, IEquatable<string>
+    public struct PlatformId : IEquatable<PlatformId>, IEquatable<string>, IComparable<string>, IComparable
     {
         private string PlatformIdString { get; }
         
@@ -24,14 +27,14 @@ namespace Snowflake.Model.Game
         }
 
         /// <inheritdoc />
-        public bool Equals(string other)
+        public bool Equals([AllowNull] string other)
         {
             return other != null &&
                    other.Equals(this.PlatformIdString, StringComparison.InvariantCultureIgnoreCase);
         }
         
         /// <inheritdoc />
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             return other switch {
                 PlatformId p => this.Equals(p),
@@ -52,15 +55,23 @@ namespace Snowflake.Model.Game
             return HashCode.Combine(PlatformIdString);
         }
 
-        
+        /// <inheritdoc />
+        public int CompareTo([AllowNull] string other)
+        {
+            return PlatformIdString.CompareTo(other);
+        }
+
+        /// <inheritdoc />
+        public int CompareTo(object? obj)
+        {
+            if (obj is PlatformId p) return PlatformIdString.CompareTo(p.PlatformIdString);
+            return PlatformIdString.CompareTo(obj);
+        }
+
+
 #pragma warning disable 1591
         public static bool operator ==(PlatformId x, PlatformId y) => x.PlatformIdString == y.PlatformIdString;
         public static bool operator !=(PlatformId x, PlatformId y) => x.PlatformIdString != y.PlatformIdString;
-
-        public static bool operator ==(string x, PlatformId y) => x.ToUpperInvariant() == y.PlatformIdString;
-        public static bool operator !=(string x, PlatformId y) => x.ToUpperInvariant() != y.PlatformIdString;
-        public static bool operator ==(PlatformId x, string y) => x.PlatformIdString == y.ToUpperInvariant();
-        public static bool operator !=(PlatformId x, string y) => x.PlatformIdString != y.ToUpperInvariant();
 #pragma warning restore 1591
 
            

--- a/src/Snowflake.Framework.Primitives/Model/Records/Game/IGameRecord.cs
+++ b/src/Snowflake.Framework.Primitives/Model/Records/Game/IGameRecord.cs
@@ -9,14 +9,14 @@ using Snowflake.Model.Records.File;
 namespace Snowflake.Model.Records.Game
 {
     /// <summary>
-    /// Represents a game as a collection of <see cref="IRecordMetadata"/> and <see cref="IFileRecord"/>s
+    /// Represents a game as a collection of <see cref="IRecordMetadata"/>.
     /// </summary>
     public interface IGameRecord : IRecord
     {
         /// <summary>
         /// Gets the Stone platform ID of this record
         /// </summary>
-        PlatformId PlatformId { get; }
+        PlatformId PlatformID { get; }
 
         /// <summary>
         /// Gets or sets the title of the game

--- a/src/Snowflake.Framework.Primitives/Model/Records/Game/IGameRecordQuery.cs
+++ b/src/Snowflake.Framework.Primitives/Model/Records/Game/IGameRecordQuery.cs
@@ -1,0 +1,25 @@
+﻿using Snowflake.Model.Game;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Snowflake.Model.Records.Game
+{
+    /// <summary>
+    /// Represents the queryable view of an <see cref="IGameRecord"/> within an 
+    /// <see cref="IGameLibrary"/>.
+    /// </summary>
+    public interface IGameRecordQuery
+    {
+        /// <summary>
+        /// Gets the Stone platform ID of this record
+        /// </summary>
+        PlatformId PlatformID { get; }
+        /// <summary>
+        /// The RecordID of the Game Record
+        /// </summary>
+        Guid RecordID { get; }
+        IEnumerable<IRecordMetadataQuery> Metadata { get; }
+    }
+}

--- a/src/Snowflake.Framework.Primitives/Model/Records/IRecord.cs
+++ b/src/Snowflake.Framework.Primitives/Model/Records/IRecord.cs
@@ -15,6 +15,6 @@ namespace Snowflake.Model.Records
         /// <summary>
         /// Gets the unique ID of the record.
         /// </summary>
-        Guid RecordId { get; }
+        Guid RecordID { get; }
     }
 }

--- a/src/Snowflake.Framework.Primitives/Model/Records/Metadata/IRecordMetadataQuery.cs
+++ b/src/Snowflake.Framework.Primitives/Model/Records/Metadata/IRecordMetadataQuery.cs
@@ -1,0 +1,31 @@
+﻿using Snowflake.Model.Game;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Snowflake.Model.Records
+{
+    /// <summary>
+    /// Represents a queryable view over metadata within a <see cref="IGameLibrary"/>
+    /// </summary>
+    public interface IRecordMetadataQuery
+    {
+        /// <summary>
+        /// The metadata key
+        /// </summary>
+        string MetadataKey { get; }
+        /// <summary>
+        /// The value of the metadata.
+        /// </summary>
+        string MetadataValue { get; }
+        /// <summary>
+        /// Gets the unique ID of the record this metadata belongs to.
+        /// </summary>
+        Guid RecordID { get; }
+        /// <summary>
+        /// Gets the unique ID of the metadata.
+        /// </summary>
+        Guid RecordMetadataID { get; }
+    }
+}

--- a/src/Snowflake.Framework.Remoting/Snowflake.Framework.Remoting.csproj
+++ b/src/Snowflake.Framework.Remoting/Snowflake.Framework.Remoting.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="3.0.0-preview-1194" />
+    <PackageReference Include="GraphQL" Version="3.0.0-preview-1269" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" PrivateAssets="Compile" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0" PrivateAssets="Compile" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />

--- a/src/Snowflake.Framework.Services/Snowflake.Framework.Services.csproj
+++ b/src/Snowflake.Framework.Services/Snowflake.Framework.Services.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Include="NLog" Version="4.6.5" PrivateAssets="Compile" />
-    <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.5.0-alpha0017" PrivateAssets="Compile" />
-    <PackageReference Include="GraphQL.Server.Transports.WebSockets" Version="3.5.0-alpha0017" PrivateAssets="Compile" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
+    <PackageReference Include="NLog" Version="4.6.7" PrivateAssets="Compile" />
+    <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.5.0-alpha0027" PrivateAssets="Compile" />
+    <PackageReference Include="GraphQL.Server.Transports.WebSockets" Version="3.5.0-alpha0027" PrivateAssets="Compile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Snowflake.Framework.Tests/Emulator/Saving/SaveLocationProviderTests.cs
+++ b/src/Snowflake.Framework.Tests/Emulator/Saving/SaveLocationProviderTests.cs
@@ -17,7 +17,7 @@ namespace Snowflake.Execution.Saving.Tests
         public async Task CreateLocation_Test()
         {
             var gameMock = new Mock<IGameRecord>();
-            gameMock.Setup(g => g.RecordId).Returns(Guid.NewGuid());
+            gameMock.Setup(g => g.RecordID).Returns(Guid.NewGuid());
             var contentDirMock = new Mock<IContentDirectoryProvider>();
             contentDirMock.Setup(g => g.ApplicationData).Returns(new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Path.GetFileNameWithoutExtension(Path.GetTempFileName())));
@@ -31,7 +31,7 @@ namespace Snowflake.Execution.Saving.Tests
         public async Task SerializeLocation_Test()
         {
             var gameMock = new Mock<IGameRecord>();
-            gameMock.Setup(g => g.RecordId).Returns(Guid.NewGuid());
+            gameMock.Setup(g => g.RecordID).Returns(Guid.NewGuid());
             var contentDirMock = new Mock<IContentDirectoryProvider>();
             contentDirMock.Setup(g => g.ApplicationData).Returns(new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Path.GetFileNameWithoutExtension(Path.GetTempFileName())));
@@ -47,7 +47,7 @@ namespace Snowflake.Execution.Saving.Tests
         public async Task EnumeratorLocation_Test()
         {
             var gameMock = new Mock<IGameRecord>();
-            gameMock.Setup(g => g.RecordId).Returns(Guid.NewGuid());
+            gameMock.Setup(g => g.RecordID).Returns(Guid.NewGuid());
             var contentDirMock = new Mock<IContentDirectoryProvider>();
             contentDirMock.Setup(g => g.ApplicationData).Returns(new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Path.GetFileNameWithoutExtension(Path.GetTempFileName())));
@@ -63,7 +63,7 @@ namespace Snowflake.Execution.Saving.Tests
         public async Task LoadLocation_Test()
         {
             var gameMock = new Mock<IGameRecord>();
-            gameMock.Setup(g => g.RecordId).Returns(Guid.NewGuid());
+            gameMock.Setup(g => g.RecordID).Returns(Guid.NewGuid());
             var contentDirMock = new Mock<IContentDirectoryProvider>();
             contentDirMock.Setup(g => g.ApplicationData).Returns(new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Path.GetFileNameWithoutExtension(Path.GetTempFileName())));
@@ -80,7 +80,7 @@ namespace Snowflake.Execution.Saving.Tests
         public async Task PersistLocation_Test()
         {
             var gameMock = new Mock<IGameRecord>();
-            gameMock.Setup(g => g.RecordId).Returns(Guid.NewGuid());
+            gameMock.Setup(g => g.RecordID).Returns(Guid.NewGuid());
             var contentDirMock = new Mock<IContentDirectoryProvider>();
             contentDirMock.Setup(g => g.ApplicationData).Returns(new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Path.GetFileNameWithoutExtension(Path.GetTempFileName())));
@@ -98,7 +98,7 @@ namespace Snowflake.Execution.Saving.Tests
         public async Task UpdateLocation_Test()
         {
             var gameMock = new Mock<IGameRecord>();
-            gameMock.Setup(g => g.RecordId).Returns(Guid.NewGuid());
+            gameMock.Setup(g => g.RecordID).Returns(Guid.NewGuid());
             var contentDirMock = new Mock<IContentDirectoryProvider>();
             contentDirMock.Setup(g => g.ApplicationData).Returns(new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Path.GetFileNameWithoutExtension(Path.GetTempFileName())));

--- a/src/Snowflake.Framework.Tests/Model/EntityGameRecordLibraryTests.cs
+++ b/src/Snowflake.Framework.Tests/Model/EntityGameRecordLibraryTests.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Snowflake.Model.Database;
 using Snowflake.Model.Database.Models;
+using Snowflake.Model.Game;
 using Snowflake.Model.Records;
+using Snowflake.Model.Records.Game;
 using Xunit;
 
 namespace Snowflake.Model.Tests
@@ -22,10 +25,10 @@ namespace Snowflake.Model.Tests
             optionsBuilder.UseSqlite($"Data Source={Path.GetTempFileName()}");
             var lib = new GameRecordLibrary(optionsBuilder);
             var record = lib.CreateRecord("NINTENDO_NES");
-            var guid = record.RecordId;
+            var guid = record.RecordID;
             var newRecord = lib.GetAllRecords().First();
-            Assert.Equal(guid, newRecord.RecordId);
-            Assert.Equal(record.PlatformId, newRecord.PlatformId);
+            Assert.Equal(guid, newRecord.RecordID);
+            Assert.Equal(record.PlatformID, newRecord.PlatformID);
         }
 
         [Fact]
@@ -36,14 +39,14 @@ namespace Snowflake.Model.Tests
 
             var lib = new GameRecordLibrary(optionsBuilder);
             var record = lib.CreateRecord("NINTENDO_NES");
-            var guid = record.RecordId;
+            var guid = record.RecordID;
 
             record.Metadata.Add("is_test", "true");
 
             lib.UpdateRecord(record);
             var newRecord = lib.GetAllRecords().First();
-            Assert.Equal(guid, newRecord.RecordId);
-            Assert.Equal(record.PlatformId, newRecord.PlatformId);
+            Assert.Equal(guid, newRecord.RecordID);
+            Assert.Equal(record.PlatformID, newRecord.PlatformID);
             Assert.Contains("is_test", newRecord.Metadata.Keys);
             Assert.Equal("true", newRecord.Metadata["is_test"]);
 
@@ -52,8 +55,8 @@ namespace Snowflake.Model.Tests
 
             var newNewRecord = lib.GetAllRecords().First();
 
-            Assert.Equal(guid, newNewRecord.RecordId);
-            Assert.Equal(record.PlatformId, newNewRecord.PlatformId);
+            Assert.Equal(guid, newNewRecord.RecordID);
+            Assert.Equal(record.PlatformID, newNewRecord.PlatformID);
             Assert.DoesNotContain("is_test", newNewRecord.Metadata.Keys);
         }
 
@@ -66,13 +69,13 @@ namespace Snowflake.Model.Tests
 
             var lib = new GameRecordLibrary(optionsBuilder);
             var record = lib.CreateRecord("NINTENDO_NES");
-            var guid = record.RecordId;
+            var guid = record.RecordID;
 
             record.Metadata.Add("is_test", "true");
             lib.UpdateRecord(record);
             var newRecord = lib.GetAllRecords().First();
-            Assert.Equal(guid, newRecord.RecordId);
-            Assert.Equal(record.PlatformId, newRecord.PlatformId);
+            Assert.Equal(guid, newRecord.RecordID);
+            Assert.Equal(record.PlatformID, newRecord.PlatformID);
             Assert.Contains("is_test", newRecord.Metadata.Keys);
             Assert.Equal("true", newRecord.Metadata["is_test"]);
 
@@ -81,8 +84,8 @@ namespace Snowflake.Model.Tests
 
             var newNewRecord = lib.GetAllRecords().First();
 
-            Assert.Equal(guid, newNewRecord.RecordId);
-            Assert.Equal(record.PlatformId, newNewRecord.PlatformId);
+            Assert.Equal(guid, newNewRecord.RecordID);
+            Assert.Equal(record.PlatformID, newNewRecord.PlatformID);
             Assert.Contains("is_test", newNewRecord.Metadata.Keys);
             Assert.Equal("true", newNewRecord.Metadata["is_test"]);
             Assert.Contains("is_test_two", newNewRecord.Metadata.Keys);
@@ -113,9 +116,9 @@ namespace Snowflake.Model.Tests
             var lib = new GameRecordLibrary(optionsBuilder);
 
             var record = lib.CreateRecord("TEST_PLATFORM");
-            Assert.NotNull(lib.GetRecord(record.RecordId));
+            Assert.NotNull(lib.GetRecord(record.RecordID));
             lib.DeleteRecord(record);
-            Assert.Null(lib.GetRecord(record.RecordId));
+            Assert.Null(lib.GetRecord(record.RecordID));
         }
 
         [Fact]
@@ -142,7 +145,7 @@ namespace Snowflake.Model.Tests
             var lib = new GameRecordLibrary(optionsBuilder);
 
             var record = lib.CreateRecord("TEST_PLATFORM");
-            Assert.NotNull(lib.GetRecord(record.RecordId));
+            Assert.NotNull(lib.GetRecord(record.RecordID));
         }
 
         [Fact]
@@ -154,7 +157,31 @@ namespace Snowflake.Model.Tests
 
             var record = lib.CreateRecord("TEST_PLATFORM");
 
-            Assert.NotEmpty(lib.GetRecords(r => r.PlatformId == "TEST_PLATFORM"));
+            Assert.NotEmpty(lib.GetRecords(r => r.PlatformID == "TEST_PLATFORM"));
+        }
+
+        [Fact]
+        public void QueryGameByPlatforms_Test()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>();
+            optionsBuilder.UseSqlite($"Data Source={Path.GetTempFileName()}");
+            var lib = new GameRecordLibrary(optionsBuilder);
+
+            var record = lib.CreateRecord("TEST_PLATFORM");
+
+            Assert.NotEmpty(lib.QueryRecords(r => r.PlatformID == "TEST_PLATFORM"));
+        }
+
+        [Fact]
+        public async Task QueryGamesByPlatformsAsync_Test()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>();
+            optionsBuilder.UseSqlite($"Data Source={Path.GetTempFileName()}");
+            var lib = new GameRecordLibrary(optionsBuilder);
+
+            var record = lib.CreateRecord("TEST_PLATFORM");
+
+            Assert.NotEmpty(await lib.QueryRecordsAsync(r => r.PlatformID == "TEST_PLATFORM"));
         }
 
         [Fact]
@@ -180,7 +207,35 @@ namespace Snowflake.Model.Tests
             record.Title = "Test";
             lib.UpdateRecord(record);
 
-            Assert.NotEmpty(lib.GetRecords(g => g.Title == "Test"));
+            Assert.NotEmpty(lib.GetRecords(g => g.Metadata[GameMetadataKeys.Title] == "Test"));
+        }
+
+        [Fact]
+        public void QueryGamesByTitle_Test()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>();
+            optionsBuilder.UseSqlite($"Data Source={Path.GetTempFileName()}");
+            var lib = new GameRecordLibrary(optionsBuilder);
+
+            var record = lib.CreateRecord("TEST_PLATFORM");
+            record.Title = "Test";
+            lib.UpdateRecord(record);
+
+            Assert.NotEmpty(lib.QueryRecords(g => g.Metadata.First(m => m.MetadataKey == GameMetadataKeys.Title).MetadataValue == "Test"));
+        }
+
+        [Fact]
+        public async Task QueryGamesByTitleAsync_Test()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>();
+            optionsBuilder.UseSqlite($"Data Source={Path.GetTempFileName()}");
+            var lib = new GameRecordLibrary(optionsBuilder);
+
+            var record = lib.CreateRecord("TEST_PLATFORM");
+            record.Title = "Test";
+            lib.UpdateRecord(record);
+
+            Assert.NotEmpty(await lib.QueryRecordsAsync(g => g.Metadata.First(m => m.MetadataKey == GameMetadataKeys.Title).MetadataValue == "Test"));
         }
     }
 }

--- a/src/Snowflake.Framework.Tests/Model/GameLibraryIntegrationTests.cs
+++ b/src/Snowflake.Framework.Tests/Model/GameLibraryIntegrationTests.cs
@@ -119,7 +119,7 @@ namespace Snowflake.Model.Tests
             record.Metadata.Add("file_metadata", "test");
             gl.GetExtension<GameFileExtensionProvider>().UpdateFile(record);
 
-            var newGame = gl.GetGame(game.Record.RecordId);
+            var newGame = gl.GetGame(game.Record.RecordID);
             Assert.NotEmpty(newGame.WithFiles().FileRecords);
         }
     }

--- a/src/Snowflake.Framework.Tests/Model/IdVerificationTests.cs
+++ b/src/Snowflake.Framework.Tests/Model/IdVerificationTests.cs
@@ -33,8 +33,8 @@ namespace Snowflake.Model.Tests
 
             Assert.NotEqual(controller, device);
             Assert.True(controller != device2);
-            Assert.True(controller != "not_ok");
 
+            Assert.Throws<InvalidControllerIdException>(() => controller != "not_ok");
             Assert.Throws<InvalidControllerIdException>(() => (ControllerId)"NOT_OK");
             Assert.Throws<InvalidControllerIdException>(() => (ControllerId)null);
 

--- a/src/Snowflake.Framework.Tests/Scraping/ScrapeContextTests.cs
+++ b/src/Snowflake.Framework.Tests/Scraping/ScrapeContextTests.cs
@@ -172,7 +172,7 @@ namespace Snowflake.Scraping.Tests
         public void GameSeedCreation_Test()
         {
             var game = new Mock<IGame>();
-            game.SetupGet(g => g.Record.PlatformId).Returns("TEST_PLATFORM");
+            game.SetupGet(g => g.Record.PlatformID).Returns("TEST_PLATFORM");
             game.SetupGet(g => g.Record.Title).Returns("Test Title");
 
             var file = new Mock<IFileRecord>();

--- a/src/Snowflake.Framework.Tests/Snowflake.Framework.Tests.csproj
+++ b/src/Snowflake.Framework.Tests/Snowflake.Framework.Tests.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
+    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="NLog" Version="4.6.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="NLog" Version="4.6.7" />
     <PackageReference Include="System.Data.HashFunction.CRC" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
@@ -26,7 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Zio" Version="0.7.4" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />

--- a/src/Snowflake.Framework/Filesystem/Directory.cs
+++ b/src/Snowflake.Framework/Filesystem/Directory.cs
@@ -26,7 +26,7 @@ namespace Snowflake.Filesystem
 
             this.Manifest =
                 new SqliteDatabase(this.RootFileSystem.ConvertPathToInternal(this.ThisDirectory.Path / ".manifest"));
-            this.Manifest.CreateTable("directory_manifest", "uuid UUID", "filename TEXT PRIMARY KEY");
+            this.Manifest.CreateTable("directory_manifest", "uuid TEXT", "filename TEXT PRIMARY KEY");
         }
 
         internal Directory(IFileSystem rootFs)
@@ -62,13 +62,13 @@ namespace Snowflake.Filesystem
         {
             return this.Manifest.Query(conn =>
             {
-                var bytes = conn.Query<byte[]>(@"SELECT uuid FROM directory_manifest WHERE filename = @file",
+                var bytes = conn.Query<string>(@"SELECT uuid FROM directory_manifest WHERE filename = @file",
                     new {file});
                 if (bytes.Count() == 0)
                 {
                     conn.Execute(@"INSERT OR REPLACE INTO directory_manifest (uuid, filename) VALUES (@guid, @file)",
                         new {guid = Guid.NewGuid(), file});
-                    bytes = conn.Query<byte[]>(@"SELECT uuid FROM directory_manifest WHERE filename = @file",
+                    bytes = conn.Query<string>(@"SELECT uuid FROM directory_manifest WHERE filename = @file",
                         new {file});
                     return new Guid(bytes.First());
                 }

--- a/src/Snowflake.Framework/Model/Database/ConfigurationCollectionStore.cs
+++ b/src/Snowflake.Framework/Model/Database/ConfigurationCollectionStore.cs
@@ -29,7 +29,7 @@ namespace Snowflake.Model.Database
             using var context = new DatabaseContext(this.Options.Options);
             return context.GameRecords
                 .Include(g => g.ConfigurationProfiles)
-                .SingleOrDefault(g => g.RecordID == gameRecord.RecordId)?
+                .SingleOrDefault(g => g.RecordID == gameRecord.RecordID)?
                 .ConfigurationProfiles
                 .GroupBy(p => p.ConfigurationSource, p => p.ProfileName) ??
                 Enumerable.Empty<IGrouping<string, string>>();
@@ -58,9 +58,9 @@ namespace Snowflake.Model.Database
 
             var gameEntity = context.GameRecords
                 .Include(p => p.ConfigurationProfiles)
-                .SingleOrDefault(p => p.RecordID == gameRecord.RecordId);
+                .SingleOrDefault(p => p.RecordID == gameRecord.RecordID);
 
-            if (gameEntity == null) throw new DependentEntityNotExistsException(gameRecord.RecordId);
+            if (gameEntity == null) throw new DependentEntityNotExistsException(gameRecord.RecordID);
 
             var entity = context.ConfigurationProfiles
                 .Add(collection.AsModel(sourceName));

--- a/src/Snowflake.Framework/Model/Database/Extensions/MetadataCollectionExtensions.cs
+++ b/src/Snowflake.Framework/Model/Database/Extensions/MetadataCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Snowflake.Model.Database.Extensions
                 }).ToList();
         }
 
-        public static IMetadataCollection AsMetadataCollection(this IEnumerable<RecordMetadataModel> @this,
+        public static IMetadataCollection AsMetadataCollection(this IEnumerable<IRecordMetadataQuery> @this,
             Guid recordGuid)
         {
             var collection = new MetadataCollection(recordGuid);

--- a/src/Snowflake.Framework/Model/Database/Extensions/RecordExtensions.cs
+++ b/src/Snowflake.Framework/Model/Database/Extensions/RecordExtensions.cs
@@ -15,8 +15,8 @@ namespace Snowflake.Model.Database.Extensions
         {
             return new GameRecordModel()
             {
-                Platform = @this.PlatformId,
-                RecordID = @this.RecordId,
+                PlatformID = @this.PlatformID,
+                RecordID = @this.RecordID,
                 RecordType = "game",
                 Metadata = @this.Metadata.AsModel()
             };
@@ -27,7 +27,7 @@ namespace Snowflake.Model.Database.Extensions
             return new FileRecordModel()
             {
                 MimeType = @this.MimeType,
-                RecordID = @this.RecordId,
+                RecordID = @this.RecordID,
                 RecordType = "file",
                 Metadata = @this.Metadata.AsModel()
             };

--- a/src/Snowflake.Framework/Model/Database/Migrations/20190925181410_InitialCreate.Designer.cs
+++ b/src/Snowflake.Framework/Model/Database/Migrations/20190925181410_InitialCreate.Designer.cs
@@ -6,24 +6,26 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Snowflake.Model.Database.Models;
 
-namespace Snowflake.Model.Database.Migrations
+namespace Snowflake.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    [Migration("20190512031719_DefaultMigrations")]
-    partial class DefaultMigrations
+    [Migration("20190925181410_InitialCreate")]
+    partial class InitialCreate
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "2.2.4-servicing-10062");
+                .HasAnnotation("ProductVersion", "3.0.0");
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.ConfigurationProfileModel", b =>
                 {
                     b.Property<Guid>("ValueCollectionGuid")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("ConfigurationSource");
+                    b.Property<string>("ConfigurationSource")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ValueCollectionGuid");
 
@@ -33,18 +35,23 @@ namespace Snowflake.Model.Database.Migrations
             modelBuilder.Entity("Snowflake.Model.Database.Models.ConfigurationValueModel", b =>
                 {
                     b.Property<Guid>("Guid")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OptionKey")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SectionKey")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Value")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
-                    b.Property<Guid>("ValueCollectionGuid");
+                    b.Property<Guid>("ValueCollectionGuid")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Guid");
 
@@ -55,11 +62,14 @@ namespace Snowflake.Model.Database.Migrations
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.ControllerElementMappingsModel", b =>
                 {
-                    b.Property<string>("ControllerID");
+                    b.Property<string>("ControllerID")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("DeviceID");
+                    b.Property<string>("DeviceID")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("ProfileName");
+                    b.Property<string>("ProfileName")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ControllerID", "DeviceID", "ProfileName");
 
@@ -68,13 +78,17 @@ namespace Snowflake.Model.Database.Migrations
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.GameRecordConfigurationProfileModel", b =>
                 {
-                    b.Property<string>("ProfileName");
+                    b.Property<string>("ProfileName")
+                        .HasColumnType("TEXT");
 
-                    b.Property<Guid>("GameID");
+                    b.Property<Guid>("GameID")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("ConfigurationSource");
+                    b.Property<string>("ConfigurationSource")
+                        .HasColumnType("TEXT");
 
-                    b.Property<Guid>("ProfileID");
+                    b.Property<Guid>("ProfileID")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ProfileName", "GameID", "ConfigurationSource");
 
@@ -88,16 +102,21 @@ namespace Snowflake.Model.Database.Migrations
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.MappedControllerElementModel", b =>
                 {
-                    b.Property<string>("ControllerID");
+                    b.Property<string>("ControllerID")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("DeviceID");
+                    b.Property<string>("DeviceID")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("ProfileName");
+                    b.Property<string>("ProfileName")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("LayoutElement");
+                    b.Property<string>("LayoutElement")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceElement")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ControllerID", "DeviceID", "ProfileName", "LayoutElement");
 
@@ -107,15 +126,19 @@ namespace Snowflake.Model.Database.Migrations
             modelBuilder.Entity("Snowflake.Model.Database.Models.RecordMetadataModel", b =>
                 {
                     b.Property<Guid>("RecordMetadataID")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MetadataKey")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MetadataValue")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
-                    b.Property<Guid>("RecordID");
+                    b.Property<Guid>("RecordID")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("RecordMetadataID");
 
@@ -127,13 +150,16 @@ namespace Snowflake.Model.Database.Migrations
             modelBuilder.Entity("Snowflake.Model.Database.Models.RecordModel", b =>
                 {
                     b.Property<Guid>("RecordID")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Discriminator")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RecordType")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.HasKey("RecordID");
 
@@ -147,7 +173,8 @@ namespace Snowflake.Model.Database.Migrations
                     b.HasBaseType("Snowflake.Model.Database.Models.RecordModel");
 
                     b.Property<string>("MimeType")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.HasDiscriminator().HasValue("FileRecordModel");
                 });
@@ -156,8 +183,9 @@ namespace Snowflake.Model.Database.Migrations
                 {
                     b.HasBaseType("Snowflake.Model.Database.Models.RecordModel");
 
-                    b.Property<string>("Platform")
-                        .IsRequired();
+                    b.Property<string>("PlatformID")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.HasDiscriminator().HasValue("GameRecordModel");
                 });
@@ -167,7 +195,8 @@ namespace Snowflake.Model.Database.Migrations
                     b.HasOne("Snowflake.Model.Database.Models.ConfigurationProfileModel", "Profile")
                         .WithMany("Values")
                         .HasForeignKey("ValueCollectionGuid")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.GameRecordConfigurationProfileModel", b =>
@@ -175,12 +204,14 @@ namespace Snowflake.Model.Database.Migrations
                     b.HasOne("Snowflake.Model.Database.Models.GameRecordModel", "Game")
                         .WithMany("ConfigurationProfiles")
                         .HasForeignKey("GameID")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
                     b.HasOne("Snowflake.Model.Database.Models.ConfigurationProfileModel", "Profile")
                         .WithOne()
                         .HasForeignKey("Snowflake.Model.Database.Models.GameRecordConfigurationProfileModel", "ProfileID")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.MappedControllerElementModel", b =>
@@ -188,7 +219,8 @@ namespace Snowflake.Model.Database.Migrations
                     b.HasOne("Snowflake.Model.Database.Models.ControllerElementMappingsModel", "Collection")
                         .WithMany("MappedElements")
                         .HasForeignKey("ControllerID", "DeviceID", "ProfileName")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.RecordMetadataModel", b =>
@@ -196,7 +228,8 @@ namespace Snowflake.Model.Database.Migrations
                     b.HasOne("Snowflake.Model.Database.Models.RecordModel", "Record")
                         .WithMany("Metadata")
                         .HasForeignKey("RecordID")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 #pragma warning restore 612, 618
         }

--- a/src/Snowflake.Framework/Model/Database/Migrations/20190925181410_InitialCreate.cs
+++ b/src/Snowflake.Framework/Model/Database/Migrations/20190925181410_InitialCreate.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace Snowflake.Model.Database.Migrations
+namespace Snowflake.Migrations
 {
-    public partial class DefaultMigrations : Migration
+    public partial class InitialCreate : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -40,7 +40,7 @@ namespace Snowflake.Model.Database.Migrations
                     RecordType = table.Column<string>(nullable: false),
                     Discriminator = table.Column<string>(nullable: false),
                     MimeType = table.Column<string>(nullable: true),
-                    Platform = table.Column<string>(nullable: true)
+                    PlatformID = table.Column<string>(nullable: true)
                 },
                 constraints: table =>
                 {

--- a/src/Snowflake.Framework/Model/Database/Migrations/DatabaseContextModelSnapshot.cs
+++ b/src/Snowflake.Framework/Model/Database/Migrations/DatabaseContextModelSnapshot.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Snowflake.Model.Database.Models;
 
-namespace Snowflake.Model.Database.Migrations
+namespace Snowflake.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
     partial class DatabaseContextModelSnapshot : ModelSnapshot
@@ -14,14 +14,16 @@ namespace Snowflake.Model.Database.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "2.2.4-servicing-10062");
+                .HasAnnotation("ProductVersion", "3.0.0");
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.ConfigurationProfileModel", b =>
                 {
                     b.Property<Guid>("ValueCollectionGuid")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("ConfigurationSource");
+                    b.Property<string>("ConfigurationSource")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ValueCollectionGuid");
 
@@ -31,18 +33,23 @@ namespace Snowflake.Model.Database.Migrations
             modelBuilder.Entity("Snowflake.Model.Database.Models.ConfigurationValueModel", b =>
                 {
                     b.Property<Guid>("Guid")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OptionKey")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SectionKey")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Value")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
-                    b.Property<Guid>("ValueCollectionGuid");
+                    b.Property<Guid>("ValueCollectionGuid")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Guid");
 
@@ -53,11 +60,14 @@ namespace Snowflake.Model.Database.Migrations
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.ControllerElementMappingsModel", b =>
                 {
-                    b.Property<string>("ControllerID");
+                    b.Property<string>("ControllerID")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("DeviceID");
+                    b.Property<string>("DeviceID")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("ProfileName");
+                    b.Property<string>("ProfileName")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ControllerID", "DeviceID", "ProfileName");
 
@@ -66,13 +76,17 @@ namespace Snowflake.Model.Database.Migrations
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.GameRecordConfigurationProfileModel", b =>
                 {
-                    b.Property<string>("ProfileName");
+                    b.Property<string>("ProfileName")
+                        .HasColumnType("TEXT");
 
-                    b.Property<Guid>("GameID");
+                    b.Property<Guid>("GameID")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("ConfigurationSource");
+                    b.Property<string>("ConfigurationSource")
+                        .HasColumnType("TEXT");
 
-                    b.Property<Guid>("ProfileID");
+                    b.Property<Guid>("ProfileID")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ProfileName", "GameID", "ConfigurationSource");
 
@@ -86,16 +100,21 @@ namespace Snowflake.Model.Database.Migrations
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.MappedControllerElementModel", b =>
                 {
-                    b.Property<string>("ControllerID");
+                    b.Property<string>("ControllerID")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("DeviceID");
+                    b.Property<string>("DeviceID")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("ProfileName");
+                    b.Property<string>("ProfileName")
+                        .HasColumnType("TEXT");
 
-                    b.Property<string>("LayoutElement");
+                    b.Property<string>("LayoutElement")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceElement")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ControllerID", "DeviceID", "ProfileName", "LayoutElement");
 
@@ -105,15 +124,19 @@ namespace Snowflake.Model.Database.Migrations
             modelBuilder.Entity("Snowflake.Model.Database.Models.RecordMetadataModel", b =>
                 {
                     b.Property<Guid>("RecordMetadataID")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MetadataKey")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MetadataValue")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
-                    b.Property<Guid>("RecordID");
+                    b.Property<Guid>("RecordID")
+                        .HasColumnType("TEXT");
 
                     b.HasKey("RecordMetadataID");
 
@@ -125,13 +148,16 @@ namespace Snowflake.Model.Database.Migrations
             modelBuilder.Entity("Snowflake.Model.Database.Models.RecordModel", b =>
                 {
                     b.Property<Guid>("RecordID")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Discriminator")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RecordType")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.HasKey("RecordID");
 
@@ -145,7 +171,8 @@ namespace Snowflake.Model.Database.Migrations
                     b.HasBaseType("Snowflake.Model.Database.Models.RecordModel");
 
                     b.Property<string>("MimeType")
-                        .IsRequired();
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.HasDiscriminator().HasValue("FileRecordModel");
                 });
@@ -154,8 +181,9 @@ namespace Snowflake.Model.Database.Migrations
                 {
                     b.HasBaseType("Snowflake.Model.Database.Models.RecordModel");
 
-                    b.Property<string>("Platform")
-                        .IsRequired();
+                    b.Property<string>("PlatformID")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.HasDiscriminator().HasValue("GameRecordModel");
                 });
@@ -165,7 +193,8 @@ namespace Snowflake.Model.Database.Migrations
                     b.HasOne("Snowflake.Model.Database.Models.ConfigurationProfileModel", "Profile")
                         .WithMany("Values")
                         .HasForeignKey("ValueCollectionGuid")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.GameRecordConfigurationProfileModel", b =>
@@ -173,12 +202,14 @@ namespace Snowflake.Model.Database.Migrations
                     b.HasOne("Snowflake.Model.Database.Models.GameRecordModel", "Game")
                         .WithMany("ConfigurationProfiles")
                         .HasForeignKey("GameID")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
                     b.HasOne("Snowflake.Model.Database.Models.ConfigurationProfileModel", "Profile")
                         .WithOne()
                         .HasForeignKey("Snowflake.Model.Database.Models.GameRecordConfigurationProfileModel", "ProfileID")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.MappedControllerElementModel", b =>
@@ -186,7 +217,8 @@ namespace Snowflake.Model.Database.Migrations
                     b.HasOne("Snowflake.Model.Database.Models.ControllerElementMappingsModel", "Collection")
                         .WithMany("MappedElements")
                         .HasForeignKey("ControllerID", "DeviceID", "ProfileName")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("Snowflake.Model.Database.Models.RecordMetadataModel", b =>
@@ -194,7 +226,8 @@ namespace Snowflake.Model.Database.Migrations
                     b.HasOne("Snowflake.Model.Database.Models.RecordModel", "Record")
                         .WithMany("Metadata")
                         .HasForeignKey("RecordID")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 #pragma warning restore 612, 618
         }

--- a/src/Snowflake.Framework/Model/Database/Models/ControllerElementMappingsModel.cs
+++ b/src/Snowflake.Framework/Model/Database/Models/ControllerElementMappingsModel.cs
@@ -11,7 +11,7 @@ namespace Snowflake.Model.Database.Models
     {
         public List<MappedControllerElementModel> MappedElements { get; set; }
 
-        public string ControllerID { get; set; }
+        public ControllerId ControllerID { get; set; }
 
         public string DeviceID { get; set; }
 
@@ -21,6 +21,7 @@ namespace Snowflake.Model.Database.Models
         {
             modelBuilder.Entity<ControllerElementMappingsModel>()
                 .Property(p => p.ControllerID)
+                .HasConversion(p => p.ToString(), s => s)
                 .IsRequired();
 
             modelBuilder.Entity<ControllerElementMappingsModel>()

--- a/src/Snowflake.Framework/Model/Database/Models/GameRecordModel.cs
+++ b/src/Snowflake.Framework/Model/Database/Models/GameRecordModel.cs
@@ -1,22 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
+using Snowflake.Model.Database.Extensions;
 using Snowflake.Model.Game;
+using Snowflake.Model.Records;
+using Snowflake.Model.Records.Game;
 
 #nullable disable
 namespace Snowflake.Model.Database.Models
 {
-    internal class GameRecordModel : RecordModel
+    internal class GameRecordModel : RecordModel, IGameRecordQuery
     {
-        public string Platform { get; set; }
+        public PlatformId PlatformID { get; set; }
 
         public List<GameRecordConfigurationProfileModel> ConfigurationProfiles { get; set; }
 
+        IEnumerable<IRecordMetadataQuery> IGameRecordQuery.Metadata => this.Metadata;
+
         internal static new void SetupModel(ModelBuilder modelBuilder)
-        {
+        {    
             modelBuilder.Entity<GameRecordModel>()
-                .Property(r => r.Platform)
+                .Property(r => r.PlatformID)
+                .HasConversion(p => p.ToString(), s => s)
                 .IsRequired();
         }
     }

--- a/src/Snowflake.Framework/Model/Database/Models/MappedControllerElementModel.cs
+++ b/src/Snowflake.Framework/Model/Database/Models/MappedControllerElementModel.cs
@@ -13,7 +13,7 @@ namespace Snowflake.Model.Database.Models
         public ControllerElement LayoutElement { get; set; }
         public ControllerElement DeviceElement { get; set; }
 
-        public string ControllerID { get; set; }
+        public ControllerId ControllerID { get; set; }
         public string DeviceID { get; set; }
         public string ProfileName { get; set; }
 
@@ -21,6 +21,10 @@ namespace Snowflake.Model.Database.Models
 
         internal static void SetupModel(ModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<MappedControllerElementModel>()
+                .Property(p => p.ControllerID)
+                .HasConversion(p => p.ToString(), s => s);
+
             modelBuilder.Entity<MappedControllerElementModel>()
                 .Property(p => p.LayoutElement)
                 .HasConversion(e => Enums.AsString(e), e => Enums.Parse<ControllerElement>(e))

--- a/src/Snowflake.Framework/Model/Database/Models/RecordMetadataModel.cs
+++ b/src/Snowflake.Framework/Model/Database/Models/RecordMetadataModel.cs
@@ -2,11 +2,12 @@
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
+using Snowflake.Model.Records;
 
 #nullable disable
 namespace Snowflake.Model.Database.Models
 {
-    internal class RecordMetadataModel
+    internal class RecordMetadataModel : IRecordMetadataQuery
     {
         public Guid RecordMetadataID { get; set; }
         public Guid RecordID { get; set; }

--- a/src/Snowflake.Framework/Model/Database/Models/RecordModel.cs
+++ b/src/Snowflake.Framework/Model/Database/Models/RecordModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
+using Snowflake.Model.Database.Extensions;
 
 #nullable disable
 namespace Snowflake.Model.Database.Models

--- a/src/Snowflake.Framework/Model/Database/RecordLibrary.cs
+++ b/src/Snowflake.Framework/Model/Database/RecordLibrary.cs
@@ -23,7 +23,7 @@ namespace Snowflake.Model.Database
         public void DeleteRecord(TRecord record)
         {
             using var context = new DatabaseContext(this.Options.Options);
-            var recordToDelete = context.Records.SingleOrDefault(r => r.RecordID == record.RecordId);
+            var recordToDelete = context.Records.SingleOrDefault(r => r.RecordID == record.RecordID);
             if (record == null) return;
             context.Entry(recordToDelete).State = EntityState.Deleted;
             context.SaveChanges();
@@ -32,7 +32,7 @@ namespace Snowflake.Model.Database
         public void UpdateRecord(TRecord record)
         {
             using var context = new DatabaseContext(this.Options.Options);
-            foreach (var metadata in context.Metadata.Where(m => m.RecordID == record.RecordId))
+            foreach (var metadata in context.Metadata.Where(m => m.RecordID == record.RecordID))
             {
                 if (!record.Metadata.ContainsKey(metadata.MetadataKey))
                 {

--- a/src/Snowflake.Framework/Model/Game/GameLibrary.cs
+++ b/src/Snowflake.Framework/Model/Game/GameLibrary.cs
@@ -90,9 +90,20 @@ namespace Snowflake.Model.Game
                 });
         }
 
-        public async Task<IEnumerable<IGame>> GetGamesAsync(Expression<Func<IGameRecord, bool>> predicate)
+        public async Task<IEnumerable<IGame>> QueryGamesAsync(Expression<Func<IGameRecordQuery, bool>> predicate)
         {
-            return (await this.GameRecordLibrary.GetRecordsAsync(predicate))
+            return (await this.GameRecordLibrary.QueryRecordsAsync(predicate))
+                .Select(gameRecord =>
+                {
+                    var extensions = this.Extensions
+                        .ToDictionary(k => k.Value.extensionType, v => v.Value.extension.MakeExtension(gameRecord));
+                    return new Game(gameRecord, extensions);
+                });
+        }
+
+        public IEnumerable<IGame> QueryGames(Expression<Func<IGameRecordQuery, bool>> predicate)
+        {
+            return this.GameRecordLibrary.QueryRecords(predicate)
                 .Select(gameRecord =>
                 {
                     var extensions = this.Extensions

--- a/src/Snowflake.Framework/Model/Game/LibraryExtensions/GameConfigurationExtension.cs
+++ b/src/Snowflake.Framework/Model/Game/LibraryExtensions/GameConfigurationExtension.cs
@@ -23,7 +23,7 @@ namespace Snowflake.Model.Game.LibraryExtensions
         public void DeleteProfile(string sourceName, string profile)
         {
             this.ConfigurationStore
-                .DeleteConfigurationForGame(this.GameRecord.RecordId, sourceName, profile);
+                .DeleteConfigurationForGame(this.GameRecord.RecordID, sourceName, profile);
         }
 
         public IEnumerable<IGrouping<string, string>> GetProfileNames()
@@ -42,7 +42,7 @@ namespace Snowflake.Model.Game.LibraryExtensions
             where T : class, IConfigurationCollection<T>
         {
             return this.ConfigurationStore
-                .GetConfiguration<T>(this.GameRecord.RecordId, sourceName, profile);
+                .GetConfiguration<T>(this.GameRecord.RecordID, sourceName, profile);
         }
     }
 }

--- a/src/Snowflake.Framework/Model/Game/LibraryExtensions/GameFileExtensionProvider.cs
+++ b/src/Snowflake.Framework/Model/Game/LibraryExtensions/GameFileExtensionProvider.cs
@@ -26,7 +26,7 @@ namespace Snowflake.Model.Game.LibraryExtensions
         public IGameFileExtension MakeExtension(IGameRecord record)
         {
             var gameFsRoot = this.GameFolderRoot
-                .GetOrCreateSubFileSystem((UPath) "/" / record.RecordId.ToString());
+                .GetOrCreateSubFileSystem((UPath) "/" / record.RecordID.ToString());
             return new GameFileExtension(gameFsRoot, this.FileLibrary);
         }
 

--- a/src/Snowflake.Framework/Model/Records/FileRecord.cs
+++ b/src/Snowflake.Framework/Model/Records/FileRecord.cs
@@ -10,7 +10,7 @@ namespace Snowflake.Model.Records
         public IMetadataCollection Metadata { get; }
 
         /// <inheritdoc/>
-        public Guid RecordId => File.FileGuid;
+        public Guid RecordID => File.FileGuid;
 
         public IFile File { get; }
 

--- a/src/Snowflake.Framework/Model/Records/GameRecord.cs
+++ b/src/Snowflake.Framework/Model/Records/GameRecord.cs
@@ -14,12 +14,12 @@ namespace Snowflake.Model.Records
             Guid recordId,
             IMetadataCollection metadata)
         {
-            this.PlatformId = platform;
-            this.RecordId = recordId;
+            this.PlatformID = platform;
+            this.RecordID = recordId;
             this.Metadata = metadata;
         }
 
-        public PlatformId PlatformId { get; }
+        public PlatformId PlatformID { get; }
 
         public string? Title
         {
@@ -29,6 +29,6 @@ namespace Snowflake.Model.Records
 
         public IMetadataCollection Metadata { get; }
 
-        public Guid RecordId { get; }
+        public Guid RecordID { get; }
     }
 }

--- a/src/Snowflake.Framework/Model/Records/RecordMetadata.cs
+++ b/src/Snowflake.Framework/Model/Records/RecordMetadata.cs
@@ -27,7 +27,7 @@ namespace Snowflake.Model.Records
         }
 
         public RecordMetadata(string key, string value, IRecord record)
-            : this(key, value, record.RecordId)
+            : this(key, value, record.RecordID)
         {
         }
 

--- a/src/Snowflake.Framework/Scraping/GameScrapeContext.cs
+++ b/src/Snowflake.Framework/Scraping/GameScrapeContext.cs
@@ -45,7 +45,7 @@ namespace Snowflake.Scraping
 
         private static IEnumerable<SeedContent> MakeGameSeeds(IGame game)
         {
-            yield return ("platform", game.Record.PlatformId);
+            yield return ("platform", game.Record.PlatformID);
             if (game.Record.Title != null) {
                 yield return ("search_title", game.Record.Title);
             }

--- a/src/Snowflake.Framework/Snowflake.Framework.csproj
+++ b/src/Snowflake.Framework/Snowflake.Framework.csproj
@@ -21,13 +21,16 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.0" PrivateAssets="Compile" />
-    <PackageReference Include="Dapper" Version="1.60.6" PrivateAssets="Compile" />
+    <PackageReference Include="Dapper" Version="2.0.4" PrivateAssets="Compile" />
     <PackageReference Include="Enums.NET" Version="2.3.2" PrivateAssets="Compile" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" PrivateAssets="Compile" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" PrivateAssets="Compile" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.4" />
-    <PackageReference Include="System.Reactive" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.0.0" PrivateAssets="Compile" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" PrivateAssets="Compile" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Reactive" Version="4.1.6" />
     <PackageReference Include="Zio" Version="0.7.4" />
   </ItemGroup>
 

--- a/src/Snowflake.Framework/Snowflake.Framework.csproj
+++ b/src/Snowflake.Framework/Snowflake.Framework.csproj
@@ -15,6 +15,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Migrations\**" />
+    <EmbeddedResource Remove="Migrations\**" />
+    <None Remove="Migrations\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="Configuration\Interceptors\ConfigurationInterceptor.cs~RF199716.TMP" />
     <None Remove="Configuration\Serialization\ConfigurationTraversalContext.cs~RF1d4d95c3.TMP" />
   </ItemGroup>

--- a/src/Snowflake.Framework/Snowflake.Framework.xml
+++ b/src/Snowflake.Framework/Snowflake.Framework.xml
@@ -1128,7 +1128,7 @@
         <member name="P:Snowflake.Model.Records.FileRecord.Metadata">
             <inheritdoc/>
         </member>
-        <member name="P:Snowflake.Model.Records.FileRecord.RecordId">
+        <member name="P:Snowflake.Model.Records.FileRecord.RecordID">
             <inheritdoc/>
         </member>
         <member name="P:Snowflake.Model.Records.FileRecord.MimeType">

--- a/src/Snowflake.Plugin.Debug.GraphQLVisualizers/GraphQLVisualizerComposable.cs
+++ b/src/Snowflake.Plugin.Debug.GraphQLVisualizers/GraphQLVisualizerComposable.cs
@@ -26,7 +26,7 @@ namespace Snowflake.Plugin.Debug.GraphQLVisualizers
         public void Configure(IApplicationBuilder app)
         {
             // use graphiQL middleware at default url /graphiql
-            app.UseGraphiQLServer(new GraphiQLOptions() { GraphiQLPath = "/debug/gql/graphiql" });
+            app.UseGraphiQLServer(new GraphiQLOptions() { Path = "/debug/gql/graphiql" });
 
             // use graphql-playground middleware at default url /ui/playground
             app.UseGraphQLPlayground(new GraphQLPlaygroundOptions() { Path = "/debug/gql/playground" });

--- a/src/Snowflake.Plugin.Debug.GraphQLVisualizers/Snowflake.Plugin.Debug.GraphQLVisualizers.csproj
+++ b/src/Snowflake.Plugin.Debug.GraphQLVisualizers/Snowflake.Plugin.Debug.GraphQLVisualizers.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="3.5.0-alpha0017" />
-    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="3.5.0-alpha0017" />
-    <PackageReference Include="GraphQL.Server.Ui.Voyager" Version="3.5.0-alpha0017" />
+    <PackageReference Include="GraphQL.Server.Ui.GraphiQL" Version="3.5.0-alpha0027" />
+    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="3.5.0-alpha0027" />
+    <PackageReference Include="GraphQL.Server.Ui.Voyager" Version="3.5.0-alpha0027" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Snowflake.Plugin.Installation.BasicInstallers/SingleFileCopyInstaller.cs
+++ b/src/Snowflake.Plugin.Installation.BasicInstallers/SingleFileCopyInstaller.cs
@@ -47,7 +47,7 @@ namespace Snowflake.Plugin.Installation.BasicInstallers
 
         public override async IAsyncEnumerable<TaskResult<IFile>> Install(IGame game, IEnumerable<FileSystemInfo> files)
         {
-            var platform =  game.Record.PlatformId;
+            var platform =  game.Record.PlatformID;
             foreach (var file in files.Select(f => f as FileInfo))
             {
                 if (file == null) continue;

--- a/src/Snowflake.Support.Execution.Providers/Saving/SaveLocationProvider.cs
+++ b/src/Snowflake.Support.Execution.Providers/Saving/SaveLocationProvider.cs
@@ -27,7 +27,7 @@ namespace Snowflake.Support.Execution
 
             DirectoryInfo locationRoot = this.SaveLocationRoot
                 .CreateSubdirectory(saveGuid.ToString());
-            var saveLocation = new SaveLocation(gameRecord.RecordId, saveType, locationRoot, saveGuid,
+            var saveLocation = new SaveLocation(gameRecord.RecordID, saveType, locationRoot, saveGuid,
                 DateTimeOffset.UtcNow);
             return await this.UpdateSaveLocation(saveLocation);
         }
@@ -64,7 +64,7 @@ namespace Snowflake.Support.Execution
         public async Task<IEnumerable<ISaveLocation>> GetSaveLocationsAsync(IGameRecord gameRecord)
         {
             return (await this.GetAllSaveLocationsAsync())
-                .Where(s => s.RecordGuid == gameRecord.RecordId);
+                .Where(s => s.RecordGuid == gameRecord.RecordID);
         }
 
         public async Task<ISaveLocation> UpdateSaveLocation(ISaveLocation location)

--- a/src/Snowflake.Support.Execution.Providers/Snowflake.Support.Execution.Providers.csproj
+++ b/src/Snowflake.Support.Execution.Providers/Snowflake.Support.Execution.Providers.csproj
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <_SnowflakeUseDevelopmentSDK>true</_SnowflakeUseDevelopmentSDK>
   </PropertyGroup>
 </Project>

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Queries/GameQueryBuilder.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Queries/GameQueryBuilder.cs
@@ -56,7 +56,7 @@ namespace Snowflake.Support.GraphQLFrameworkQueries.Queries
 
             var installer = this.Installers.FirstOrDefault(p => p.SupportedPlatforms.Contains(platform));
             if (installer == null) throw new KeyNotFoundException("Platform Not Found");
-            return await this.InstallQueue.QueueJob(installer.Install(game, filesysinfo), game.Record.RecordId);
+            return await this.InstallQueue.QueueJob(installer.Install(game, filesysinfo), game.Record.RecordID);
         }
 
         [Mutation("installNextStep", "Proceeds with the next step of the installation process", typeof(FileGraphType))]

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Queries/RecordQueryBuilder.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Queries/RecordQueryBuilder.cs
@@ -92,7 +92,7 @@ namespace Snowflake.Support.Remoting.GraphQL.Queries
                 }
 
                 this.GameLibrary.UpdateGameRecord(game.Record);
-                return this.GameLibrary.GetGame(game.Record.RecordId);
+                return this.GameLibrary.GetGame(game.Record.RecordID);
             }
             catch (KeyNotFoundException)
             {

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Snowflake.Support.GraphQLFrameworkQueries.csproj
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Snowflake.Support.GraphQLFrameworkQueries.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="3.0.0-preview-1194" />
+    <PackageReference Include="GraphQL" Version="3.0.0-preview-1269" />
   </ItemGroup>
   
 <ItemGroup>

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Types/Model/FileRecordGraphType.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Types/Model/FileRecordGraphType.cs
@@ -20,11 +20,11 @@ namespace Snowflake.Support.Remoting.GraphQL.Types.Model
 
             Field<GuidGraphType>("guid",
                 description: "The unique ID of the file.",
-                resolve: context => context.Source.RecordId);
+                resolve: context => context.Source.RecordID);
 
             Field<StringGraphType>("id",
                 description: "The opaque GraphQL unique ID of the file. For caching purposes only.",
-                resolve: context => context.Source.RecordId.ToGraphQlUniqueId("FileRecord"));
+                resolve: context => context.Source.RecordID.ToGraphQlUniqueId("FileRecord"));
 
             Field<ListGraphType<RecordMetadataGraphType>>(
                 "metadata",

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Types/Model/GameRecordGraphType.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Types/Model/GameRecordGraphType.cs
@@ -23,15 +23,15 @@ namespace Snowflake.Support.Remoting.GraphQL.Types.Model
 
             Field<StringGraphType>("platformId",
                 description: "The platform or console this game was created for",
-                resolve: context => context.Source.PlatformId.ToString());
+                resolve: context => context.Source.PlatformID.ToString());
 
             Field<GuidGraphType>("guid",
                 description: "The unique ID of the game.",
-                resolve: context => context.Source.RecordId);
+                resolve: context => context.Source.RecordID);
 
             Field<StringGraphType>("id",
                 description: "The opaque GraphQL unique ID of the game. For caching purposes only.",
-                resolve: context => context.Source.RecordId.ToGraphQlUniqueId("GameRecord"));
+                resolve: context => context.Source.RecordID.ToGraphQlUniqueId("GameRecord"));
 
             Field<ListGraphType<RecordMetadataGraphType>>(
                 "metadata",

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Types/Model/RecordInterface.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Types/Model/RecordInterface.cs
@@ -18,7 +18,7 @@ namespace Snowflake.Support.Remoting.GraphQL.Types.Model
 
             Field<StringGraphType>("id",
                 description: "The opaque GraphQL unique ID of the game. For caching purposes only.",
-                resolve: context => context.Source.RecordId.ToGraphQlUniqueId("Record"));
+                resolve: context => context.Source.RecordID.ToGraphQlUniqueId("Record"));
 
             Field<ListGraphType<RecordMetadataGraphType>>(
                 "metadata",

--- a/src/Snowflake.Support.StoneProvider/Snowflake.Support.StoneProvider.csproj
+++ b/src/Snowflake.Support.StoneProvider/Snowflake.Support.StoneProvider.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="DiscUtils.Core" Version="0.15.1-ci0002" />
     <PackageReference Include="DiscUtils.Iso9660" Version="0.15.1-ci0002" />
-    <PackageReference Include="MimeMapping" Version="1.0.1.12" />
+    <PackageReference Include="MimeMapping" Version="1.0.1.17" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Snowflake.Support.StoreProviders/Snowflake.Support.StoreProviders.csproj
+++ b/src/Snowflake.Support.StoreProviders/Snowflake.Support.StoreProviders.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0" />
   </ItemGroup>
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\Snowflake.ruleset</CodeAnalysisRuleSet>

--- a/src/Snowflake.Tooling.Taskrunner/Snowflake.Tooling.Taskrunner.csproj
+++ b/src/Snowflake.Tooling.Taskrunner/Snowflake.Tooling.Taskrunner.csproj
@@ -28,9 +28,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="SharpZipLib" Version="1.1.0" />
+    <PackageReference Include="SharpZipLib" Version="1.2.0" />
     <PackageReference Include="System.Interactive" Version="3.2.0" />
   </ItemGroup>
 

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100-preview7-012821"
+    "version": "3.0.100"
   },
   "msbuild-sdks": {
     "Snowflake.Framework.Dependencies.Sdk": "2.0.0",


### PR DESCRIPTION
* Update Azure build to .NET Core 3
* Update EF Core 3.0
* Removed (ControllerId|PlatformId, string) comparisons and vice versa (now must always rely on implicit casts)
* Changed `IGameLibrary` API to make client-side queries more clear.