### PR TITLE
GraphQL Endpoints for New Orchestration API and API Cleanups

### DIFF
--- a/build/Snowflake.Tooling.BuildScript.csproj
+++ b/build/Snowflake.Tooling.BuildScript.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace></RootNamespace>
     <IsPackable>False</IsPackable>

--- a/src/Snowflake.Bootstrap.Windows/SnowflakeShell.cs
+++ b/src/Snowflake.Bootstrap.Windows/SnowflakeShell.cs
@@ -26,7 +26,7 @@ namespace Snowflake.Shell.Windows
 
         public void StartCore()
         {
-            this.loadedCore = new ServiceContainer(this.appDataDirectory);
+            this.loadedCore = new ServiceContainer(this.appDataDirectory, "http://localhost:9797");
             var loader = this.loadedCore.Get<IModuleEnumerator>();
             var composer = new AssemblyComposer(this.loadedCore, loader);
             composer.Compose();

--- a/src/Snowflake.Framework.Primitives/Extensibility/IPluginCollection.cs
+++ b/src/Snowflake.Framework.Primitives/Extensibility/IPluginCollection.cs
@@ -11,13 +11,13 @@ namespace Snowflake.Extensibility
     /// </summary>
     /// <typeparam name="T">The type of plugin</typeparam>
     public interface IPluginCollection<T> : IEnumerable<T>
-        where T : IPlugin
+        where T : class, IPlugin
     {
         /// <summary>
         /// Gets the instance of T.
         /// </summary>
         /// <param name="pluginName">The name of the plugin</param>
         /// <returns>An instance of the plugin with the given plugin name. </returns>
-        T this[string pluginName] { get; }
+        T? this[string pluginName] { get; }
     }
 }

--- a/src/Snowflake.Framework.Primitives/Loader/IComposable.cs
+++ b/src/Snowflake.Framework.Primitives/Loader/IComposable.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Snowflake.Services;
 
 namespace Snowflake.Loader

--- a/src/Snowflake.Framework.Primitives/Loader/IComposable.cs
+++ b/src/Snowflake.Framework.Primitives/Loader/IComposable.cs
@@ -5,7 +5,7 @@ using Snowflake.Services;
 namespace Snowflake.Loader
 {
     /// <summary>
-    /// A container for plugins to initialize in.
+    /// A container for modules and plugins to initialize in.
     /// All composable objects must implement this interface, and register their plugins inside the
     /// Compose method.
     /// </summary>
@@ -14,10 +14,15 @@ namespace Snowflake.Loader
         /// <summary>
         /// This method is called upon initialization of your plugin assembly.
         /// In this method, initialize your plugin objects and register them to the plugin manager to expose access to Snowflake.
+        /// <para>
+        /// Access to various services in the <see cref="IServiceRepository"/> must be negotiated for using
+        /// <see cref="ImportServiceAttribute"/>. Some important services are <see cref="IPluginManager"/>,
+        /// as well as <see cref="IServiceRegistrationProvider"/> to register your own services.
+        /// </para>
         /// </summary>
         /// <param name="composableModule">The module metadata of the loading module.</param>
-        /// <param name="serviceContainer">The service container that is injected by the plugin manager.</param>
+        /// <param name="serviceRepository">The services that are injected by the module compositor.</param>
         /// <see cref="IPluginManager.Register{T}(T)"/>
-        void Compose(IModule composableModule, IServiceRepository serviceContainer);
+        void Compose(IModule composableModule, IServiceRepository serviceRepository);
     }
 }

--- a/src/Snowflake.Framework.Primitives/Services/IContentDirectoryProvider.cs
+++ b/src/Snowflake.Framework.Primitives/Services/IContentDirectoryProvider.cs
@@ -1,12 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Snowflake.Extensibility;
+using Snowflake.Extensibility.Provisioning;
 using System.IO;
-using System.Text;
 
 namespace Snowflake.Services
 {
     /// <summary>
     /// Provides the application content directory.
+    /// <para>
+    /// Often this is unneeded. Prefer the Snowflake <see cref="Snowflake.Filesystem"/> API if possible.
+    /// If you are writing a provisioned <see cref="IPlugin"/>, a working directory has already been provided to you through the
+    /// Filesystem API through <see cref="IPluginProvision"/>.
+    /// </para>
+    /// <para>
+    /// If you are writing a service, you may also be interested in the Zio.IFileSystem service for safer filesystem access.
+    /// </para>
     /// </summary>
     public interface IContentDirectoryProvider
     {

--- a/src/Snowflake.Framework.Primitives/Services/IPluginManager.cs
+++ b/src/Snowflake.Framework.Primitives/Services/IPluginManager.cs
@@ -18,7 +18,7 @@ namespace Snowflake.Services
         /// <param name="module">The module the plugin is loaded from</param>
         /// <returns>A provision used to initialize an <see cref="IProvisionedPlugin"/></returns>
         IPluginProvision GetProvision<T>(IModule module)
-            where T : IPlugin;
+            where T : class, IPlugin;
 
         /// <summary>
         /// Registers a plugin with the plugin manager.
@@ -28,7 +28,7 @@ namespace Snowflake.Services
         /// </typeparam>
         /// <param name="plugin">The plugin instance</param>
         void Register<T>(T plugin)
-            where T : IPlugin;
+            where T : class, IPlugin;
 
         /// <summary>
         /// Gets all plugins registered under the type category
@@ -38,7 +38,7 @@ namespace Snowflake.Services
         /// </typeparam>
         /// <returns>All plugins registered under a specific category.</returns>
         IEnumerable<T> Get<T>()
-            where T : IPlugin;
+            where T : class, IPlugin;
 
         /// <summary>
         /// Gets all plugins registered under the type category as a plugin collection.
@@ -48,7 +48,7 @@ namespace Snowflake.Services
         /// </typeparam>
         /// <returns>All plugins registered under a specific category.</returns>
         IPluginCollection<T> GetCollection<T>()
-            where T : IPlugin;
+            where T : class, IPlugin;
 
         /// <summary>
         /// Gets a specific plugin registered under a given type category
@@ -58,8 +58,8 @@ namespace Snowflake.Services
         /// </typeparam>
         /// <param name="pluginName">The name of the plugin.</param>
         /// <returns>The given plugin if it exists, null if it does not.</returns>
-        T Get<T>(string pluginName)
-            where T : IPlugin;
+        T? Get<T>(string pluginName)
+            where T : class, IPlugin;
 
         /// <summary>
         /// Gets a specific provisioned plugin
@@ -77,7 +77,7 @@ namespace Snowflake.Services
         /// <param name="pluginName">The name of the plugin.</param>
         /// <returns>True if the plugin has been registered.</returns>
         bool IsRegistered<T>(string pluginName)
-            where T : IPlugin;
+            where T : class, IPlugin;
 
         /// <summary>
         /// Checks if a given plugin has been loaded into the plugin manager.

--- a/src/Snowflake.Framework.Primitives/Services/IServiceContainer.cs
+++ b/src/Snowflake.Framework.Primitives/Services/IServiceContainer.cs
@@ -19,10 +19,11 @@ namespace Snowflake.Services
         string AppDataDirectory { get; }
 
         /// <summary>
-        /// Register a service with this coreservice
+        /// Register a new singleton service.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="serviceInstance"></param>
+        /// <typeparam name="T">The type of the service.</typeparam>
+        /// <param name="serviceInstance">The instance of the service.</param>
+        /// <exception cref="ArgumentException">Thrown when a service of the same type already exists.</exception>
         void RegisterService<T>(T serviceInstance);
 
         /// <summary>

--- a/src/Snowflake.Framework.Primitives/Services/IServiceContainer.cs
+++ b/src/Snowflake.Framework.Primitives/Services/IServiceContainer.cs
@@ -6,6 +6,10 @@ namespace Snowflake.Services
 {
     /// <summary>
     /// The core frontend service that handles all the functions of the frontend core.
+    /// Acts as a dependency injection container for all <see cref="IComposable"/> modules.
+    /// An instance of <see cref="IServiceContainer"/> can not be directly obtained. Instead,
+    /// services within it must be requested using <see cref="ImportServiceAttribute"/>, and
+    /// new services can be registered using the <see cref="IServiceRegistrationProvider"/> service.
     /// </summary>
     public interface IServiceContainer : IDisposable
     {

--- a/src/Snowflake.Framework.Primitives/Services/IServiceRegistrationProvider.cs
+++ b/src/Snowflake.Framework.Primitives/Services/IServiceRegistrationProvider.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Snowflake.Services
@@ -7,18 +7,29 @@ namespace Snowflake.Services
     /// <summary>
     /// Provides facilities to register a service.
     /// <para>
-    /// When registering a service, your service must implement an interface in an assembly
-    /// outside of the plugin composable.
-    /// Otherwise, your service will never be accessible by any consumer.
+    /// A service must implement an interface that resides outside of its implementing assembly. A service that implements
+    /// an interface in its own assembly will not be accessible by any consumer due to resolution rules. This is true even
+    /// for a service that only exposes a private API. In such case, it is advisable to expose an internal API, and use
+    /// <see cref="InternalsVisibleToAttribute"/> to expose the interface.
     /// </para>
     /// </summary>
     public interface IServiceRegistrationProvider
     {
         /// <summary>
-        /// Registers a service with the current service singleton
+        /// Registers a singleton service with the service container.
+        /// <para>
+        /// A service must implement an interface that resides outside of its implementing assembly. A service that implements
+        /// an interface in its own assembly will not be accessible by any consumer due to resolution rules. This is true even
+        /// for a service that only exposes a private API. In such case, it is advisable to expose an internal API, and use
+        /// <see cref="InternalsVisibleToAttribute"/> to expose the interface.
+        /// </para>
         /// </summary>
-        /// <typeparam name="T">The type of service to register</typeparam>
-        /// <param name="serviceInstance">The instance of the service</param>
+        /// <typeparam name="T">The type of the service to register.</typeparam>
+        /// <param name="serviceInstance">The instance of the service to register.</param>
+        /// <exception cref="ArgumentException">Thrown when a service of the same type was already registered.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when a service and its implementing type reside in the same assembly.
+        /// </exception>
         void RegisterService<T>(T serviceInstance)
             where T : class;
     }

--- a/src/Snowflake.Framework.Remoting/AsyncJobQueue.cs
+++ b/src/Snowflake.Framework.Remoting/AsyncJobQueue.cs
@@ -71,10 +71,12 @@ namespace Snowflake.Framework.Extensibility
             return value;
         }
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         private static async IAsyncEnumerable<T> Empty()
         {
             yield break;
         }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 
         public async ValueTask<(T, bool)> GetNext(Guid jobId)
         {

--- a/src/Snowflake.Framework.Remoting/AsyncJobQueue.cs
+++ b/src/Snowflake.Framework.Remoting/AsyncJobQueue.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace Snowflake.Framework.Extensibility
 {
+    /// <inheritdoc />
     public sealed class AsyncJobQueue<T> : IAsyncJobQueue<T>
     {
         private sealed class AsyncJobQueueEnumerable : IAsyncEnumerable<T>
@@ -77,7 +78,7 @@ namespace Snowflake.Framework.Extensibility
             yield break;
         }
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
-
+        /// <inheritdoc />
         public async ValueTask<(T, bool)> GetNext(Guid jobId)
         {
             var enumerator = this.GetEnumerator(jobId);
@@ -97,6 +98,7 @@ namespace Snowflake.Framework.Extensibility
             return result;
         }
 
+        /// <inheritdoc />
         public ValueTask<Guid> QueueJob(IAsyncEnumerable<T> asyncEnumerable, CancellationToken token = default)
         {
             var guid = Guid.NewGuid();
@@ -106,6 +108,7 @@ namespace Snowflake.Framework.Extensibility
             return new ValueTask<Guid>(guid);
         }
 
+        /// <inheritdoc />
         public async ValueTask<Guid> QueueJob(IAsyncEnumerable<T> asyncEnumerable, Guid guid, CancellationToken token = default)
         {
             if (this.Enumerators.TryGetValue(guid, out IAsyncEnumerator<T> old))
@@ -125,17 +128,20 @@ namespace Snowflake.Framework.Extensibility
             return guid;
         }
 
+        /// <inheritdoc />
         public IAsyncEnumerable<T> AsEnumerable(Guid jobId)
         {
             return new AsyncJobQueueEnumerable(this, jobId);
         }
 
+        /// <inheritdoc />
         public IAsyncEnumerable<T> GetSource(Guid jobId)
         {
             this.Enumerables.TryGetValue(jobId, out var enumerable);
             return enumerable;
         }
 
+        /// <inheritdoc />
         public bool TryRemoveSource(Guid jobId, out IAsyncEnumerable<T> asyncEnumerable)
         {
             asyncEnumerable = Empty();

--- a/src/Snowflake.Framework.Remoting/Electron/IElectronPackage.cs
+++ b/src/Snowflake.Framework.Remoting/Electron/IElectronPackage.cs
@@ -4,14 +4,38 @@ using System.Text;
 
 namespace Snowflake.Framework.Remoting.Electron
 {
+    /// <summary>
+    /// Represents a loadable Electron package, that usually implements a user interface.
+    /// </summary>
     public interface IElectronPackage
     {
+        /// <summary>
+        /// The author of the package.
+        /// </summary>
         string Author { get; }
+        /// <summary>
+        /// The path of the package on disk.
+        /// </summary>
         string PackagePath { get; }
+        /// <summary>
+        /// The "homepage", or entry file to use when loading this theme in Electron.
+        /// </summary>
         string Entry { get; }
+        /// <summary>
+        /// The theme icon.
+        /// </summary>
         string Icon { get; }
+        /// <summary>
+        /// A description of this theme.
+        /// </summary>
         string Description { get; }
+        /// <summary>
+        /// The name of this theme.
+        /// </summary>
         string Name { get; }
+        /// <summary>
+        /// The version of this theme.
+        /// </summary>
         string Version { get; }
     }
 }

--- a/src/Snowflake.Framework.Remoting/Electron/IElectronPackageProvider.cs
+++ b/src/Snowflake.Framework.Remoting/Electron/IElectronPackageProvider.cs
@@ -3,8 +3,14 @@ using System.Collections.Generic;
 
 namespace Snowflake.Framework.Remoting.Electron
 {
+    /// <summary>
+    /// A service that provides access to Electron package manifests.
+    /// </summary>
     public interface IElectronPackageProvider
     {
+        /// <summary>
+        /// A list of loaded Electron packages that implement user interfaces.
+        /// </summary>
         IEnumerable<IElectronPackage> Interfaces { get; }
     }
 }

--- a/src/Snowflake.Framework.Remoting/GraphQL/Attributes/ConnectionAttribute.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/Attributes/ConnectionAttribute.cs
@@ -6,13 +6,40 @@ using GraphQL.Types;
 
 namespace Snowflake.Framework.Remoting.GraphQL.Attributes
 {
+    /// <summary>
+    /// <para>
+    /// A Connection is a common idiom in GraphQL that implements cursor-based pagination for enumerable objects.
+    /// Methods marked with <see cref="ConnectionAttribute"/> must return <see cref="IEnumerable{T}"/>.
+    /// if the returned <see cref="IEnumerable{T}"/> is impure, cursors may become
+    /// potentialy meaningless, since nothing is cached between calls of the same method.
+    /// </para>
+    /// <para>
+    /// A method can only be marked with one of <see cref="ConnectionAttribute"/>, <see cref="FieldAttribute"/>, or <see cref="MutationAttribute"/>,
+    /// never more than one.
+    /// </para>
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public sealed class ConnectionAttribute : Attribute
     {
+        /// <summary>
+        /// The <see cref="ObjectGraphType"/> conversion of the type that is contained with the enumerable return type.
+        /// </summary>
         public Type GraphType { get; }
+        /// <summary>
+        /// The name of the GraphQL field to expose.
+        /// </summary>
         public string FieldName { get; }
+        /// <summary>
+        /// The description of the field.
+        /// </summary>
         public string Description { get; }
 
+        /// <summary>
+        /// Marks a method as a GraphQL Connection. Connection methods must return <see cref="IEnumerable{T}"/>.
+        /// </summary>
+        /// <param name="fieldName">The name of the GraphQL field to expose.</param>
+        /// <param name="description">The description of the field.</param>
+        /// <param name="graphType">The <see cref="ObjectGraphType"/> conversion of the type that is contained with the enumerable return type.</param>
         public ConnectionAttribute(string fieldName, string description, Type graphType)
         {
             this.GraphType = graphType;

--- a/src/Snowflake.Framework.Remoting/GraphQL/Attributes/FieldAttribute.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/Attributes/FieldAttribute.cs
@@ -6,13 +6,38 @@ using GraphQL.Types;
 
 namespace Snowflake.Framework.Remoting.GraphQL.Attributes
 {
+    /// <summary>
+    /// <para>
+    /// A GraphQL field in this context is specifically a field on the query root object. This attribute will mark
+    /// a method as being a GraphQL field on the query root object, and thus makes a method available to the GraphQL query schema.
+    /// </para>
+    /// <para>
+    /// A method can only be marked with one of <see cref="ConnectionAttribute"/>, <see cref="FieldAttribute"/>, or <see cref="MutationAttribute"/>,
+    /// never more than one.
+    /// </para>
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public sealed class FieldAttribute : Attribute
     {
+        /// <summary>
+        /// The <see cref="ObjectGraphType"/> conversion of the return type.
+        /// </summary>
         public Type GraphType { get; }
+        /// <summary>
+        /// The name of the GraphQL field to expose.
+        /// </summary>
         public string FieldName { get; }
+        /// <summary>
+        /// The description of the field.
+        /// </summary>
         public string Description { get; }
 
+        /// <summary>
+        /// Marks a method as a basic GraphQL field./>.
+        /// </summary>
+        /// <param name="fieldName">The name of the GraphQL field to expose.</param>
+        /// <param name="description">The description of the field.</param>
+        /// <param name="graphType">The <see cref="ObjectGraphType"/> conversion of the return type.</param>
         public FieldAttribute(string fieldName, string description, Type graphType)
         {
             this.GraphType = graphType;

--- a/src/Snowflake.Framework.Remoting/GraphQL/Attributes/MutationAttribute.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/Attributes/MutationAttribute.cs
@@ -6,13 +6,39 @@ using GraphQL.Types;
 
 namespace Snowflake.Framework.Remoting.GraphQL.Attributes
 {
+    /// <summary>
+    /// <para>
+    /// A mutation field in this context is simply a normal field on the mutation root object.
+    /// By convention, only fields in the mutation root object may mutate state, as compared to <see cref="FieldAttribute"/>,
+    /// which will attach the method as a field on the query root object instead.
+    /// </para>
+    /// <para>
+    /// A method can only be marked with one of <see cref="ConnectionAttribute"/>, <see cref="FieldAttribute"/>, or <see cref="MutationAttribute"/>,
+    /// never more than one.
+    /// </para>
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public sealed class MutationAttribute : Attribute
     {
+        /// <summary>
+        /// The <see cref="ObjectGraphType"/> conversion of the return type.
+        /// </summary>
         public Type GraphType { get; }
+        /// <summary>
+        /// The name of the GraphQL field to expose.
+        /// </summary>
         public string FieldName { get; }
+        /// <summary>
+        /// The description of the field.
+        /// </summary>
         public string Description { get; }
-
+        
+        /// <summary>
+        /// Marks a method as a GraphQL field on the mutation root object./>.
+        /// </summary>
+        /// <param name="fieldName">The name of the GraphQL field to expose.</param>
+        /// <param name="description">The description of the field.</param>
+        /// <param name="graphType">The <see cref="ObjectGraphType"/> conversion of the return type.</param>
         public MutationAttribute(string fieldName, string description, Type graphType)
         {
             this.GraphType = graphType;

--- a/src/Snowflake.Framework.Remoting/GraphQL/Attributes/ParameterAttribute.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/Attributes/ParameterAttribute.cs
@@ -5,23 +5,70 @@ using GraphQL.Types;
 
 namespace Snowflake.Framework.Remoting.GraphQL.Attributes
 {
+    /// <summary>
+    /// Describes a parameter in a method's argument list, providing necesssary details about
+    /// a given parameter so that it may be called from GraphQL.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public sealed class ParameterAttribute : Attribute
     {
+        /// <summary>
+        /// The native CLR type of the parameter.
+        /// </summary>
         public Type ParameterType { get; }
+
+        /// <summary>
+        /// The type of the GraphQL <see cref="ObjectGraphType"/> or <see cref="InputObjectGraphType"/> conversion of
+        /// the <see cref="ParameterType"/>.
+        /// </summary>
         public Type GraphQlType { get; }
+
+        /// <summary>
+        /// The name of the argument as it appears in the method's argument list.
+        /// </summary>
         public string Key { get; }
+
+        /// <summary>
+        /// A description of the argument for use in GraphQL documentation introspection.
+        /// </summary>
         public string Description { get; }
+
+        /// <summary>
+        /// Whether or not the parameter is nullable, or strictly non-null.
+        /// </summary>
         public bool Nullable { get; }
+
+        /// <summary>
+        /// Specifies a type to convert the <see cref="ParameterType"/> into before applying the <see cref="GraphQlType"/>
+        /// transformation. Currently unimplemented.
+        /// </summary>
+        [Obsolete("Auto-conversion of parameter types is currently unimplemented, and does nothing.")]
         public Type ConvertableType { get; }
 
+        /// <summary>
+        /// Describes a parameter in a method's argument list, providing necesssary details about
+        /// a given parameter so that it may be called from GraphQL.
+        /// </summary>
+        /// <param name="parameterType">The native CLR type of the parameter.</param>
+        /// <param name="graphQlType">
+        /// The type of the GraphQL <see cref="ObjectGraphType"/> or <see cref="InputObjectGraphType"/> conversion of
+        /// the <see cref="ParameterType"/>.
+        /// </param>
+        /// <param name="parameterKey">The name of the argument as it appears in the method's argument list.</param>
+        /// <param name="description">A description of the argument for use in GraphQL documentation introspection.</param>
+        /// <param name="nullable">Whether or not the parameter is nullable, or strictly non-null.</param>
+        /// <param name="convertableType">Reserved for future use.</param>
         public ParameterAttribute(Type parameterType, Type graphQlType, string parameterKey, string description,
             bool nullable = false, Type convertableType = null)
         {
             this.ParameterType = parameterType;
             this.Key = parameterKey;
             this.Description = description;
+            this.Nullable = nullable;
             this.GraphQlType = nullable ? graphQlType : typeof(NonNullGraphType<>).MakeGenericType(graphQlType);
+#pragma warning disable CS0618 // Type or member is obsolete
+            this.ConvertableType = convertableType;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/Snowflake.Framework.Remoting/GraphQL/Connections/ArraySliceMetrics.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/Connections/ArraySliceMetrics.cs
@@ -7,35 +7,35 @@ using GraphQL.Relay.Utilities;
 
 namespace GraphQL.Relay.Types
 {
-    internal struct ArraySliceMetrics<TSource, TParent>
+    internal ref struct ArraySliceMetrics<TSource, TParent>
     {
         private IList<TSource> _items;
 
         /// <summary>
         /// Gets or sets the Total number of items in outer list. May be >= the SliceSize
         /// </summary>
-        public int TotalCount { get; set; }
+        public int TotalCount { get; }
 
         /// <summary>
         /// Gets or sets the local total of the list slice.
         /// </summary>
-        public int SliceSize { get; set; }
+        public int SliceSize { get; }
 
         /// <summary>
         /// Gets or sets the start index of the slice within the larger List
         /// </summary>
         /// <returns></returns>
-        public int StartIndex { get; set; } 
+        public int StartIndex { get; } 
 
         /// <summary>
         /// Gets the end index of the slice within the larger List
         /// </summary>
         public int EndIndex => this.StartIndex + this.SliceSize;
 
-        public int StartOffset { get; set; }
-        public int EndOffset { get; set; }
-        public bool HasPrevious { get; set; }
-        public bool HasNext { get; set; }
+        public int StartOffset { get; }
+        public int EndOffset { get; }
+        public bool HasPrevious { get; }
+        public bool HasNext { get; }
 
         public ArraySliceMetrics(
             IList<TSource> slice,
@@ -63,9 +63,9 @@ namespace GraphQL.Relay.Types
 
             var beforeOffset = ConnectionUtils.OffsetOrDefault(context.Before, totalCount);
             var afterOffset = ConnectionUtils.OffsetOrDefault(context.After, defaultOffset: -1);
-
-            this.StartOffset = new[] {sliceStartIndex - 1, afterOffset, -1}.Max() + 1;
-            this.EndOffset = new[] {endIndex - 1, beforeOffset, totalCount}.Max();
+           
+            this.StartOffset =  Math.Max(sliceStartIndex - 1, Math.Max(afterOffset, -1)) + 1;
+            this.EndOffset = Math.Max(endIndex - 1, Math.Max(beforeOffset, totalCount));
 
             if (context.First.HasValue)
             {

--- a/src/Snowflake.Framework.Remoting/GraphQL/Connections/ArraySliceMetrics.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/Connections/ArraySliceMetrics.cs
@@ -7,7 +7,7 @@ using GraphQL.Relay.Utilities;
 
 namespace GraphQL.Relay.Types
 {
-    internal class ArraySliceMetrics<TSource, TParent>
+    internal struct ArraySliceMetrics<TSource, TParent>
     {
         private IList<TSource> _items;
 
@@ -25,12 +25,12 @@ namespace GraphQL.Relay.Types
         /// Gets or sets the start index of the slice within the larger List
         /// </summary>
         /// <returns></returns>
-        public int StartIndex { get; set; } = 0;
+        public int StartIndex { get; set; } 
 
         /// <summary>
         /// Gets the end index of the slice within the larger List
         /// </summary>
-        public int EndIndex => StartIndex + SliceSize;
+        public int EndIndex => this.StartIndex + this.SliceSize;
 
         public int StartOffset { get; set; }
         public int EndOffset { get; set; }
@@ -56,30 +56,33 @@ namespace GraphQL.Relay.Types
         {
             _items = slice;
 
-            SliceSize = slice.Count;
-            StartIndex = sliceStartIndex;
+            this.SliceSize = slice.Count;
+            this.StartIndex = sliceStartIndex;
+
+            var endIndex = this.StartIndex + this.SliceSize;
 
             var beforeOffset = ConnectionUtils.OffsetOrDefault(context.Before, totalCount);
             var afterOffset = ConnectionUtils.OffsetOrDefault(context.After, defaultOffset: -1);
 
-            StartOffset = new[] {sliceStartIndex - 1, afterOffset, -1}.Max() + 1;
-            EndOffset = new[] {EndIndex - 1, beforeOffset, totalCount}.Max();
+            this.StartOffset = new[] {sliceStartIndex - 1, afterOffset, -1}.Max() + 1;
+            this.EndOffset = new[] {endIndex - 1, beforeOffset, totalCount}.Max();
 
             if (context.First.HasValue)
             {
-                EndOffset = Math.Min(EndOffset, StartOffset + context.First.Value);
+                this.EndOffset = Math.Min(this.EndOffset, this.StartOffset + context.First.Value);
             }
 
             if (context.Last.HasValue)
             {
-                StartOffset = Math.Min(StartOffset, EndOffset - context.Last.Value);
+                this.StartOffset = Math.Min(this.StartOffset, this.EndOffset - context.Last.Value);
             }
 
             var lowerBound = context.After != null ? afterOffset + 1 : 0;
             var upperBound = context.Before != null ? beforeOffset : totalCount;
 
-            HasPrevious = context.Last.HasValue && StartOffset > lowerBound;
-            HasNext = context.First.HasValue && EndOffset < upperBound;
+            this.HasPrevious = context.Last.HasValue && this.StartOffset > lowerBound;
+            this.HasNext = context.First.HasValue && this.EndOffset < upperBound;
+            this.TotalCount = totalCount;
         }
     }
 }

--- a/src/Snowflake.Framework.Remoting/GraphQL/Connections/ConnectionUtils.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/Connections/ConnectionUtils.cs
@@ -57,11 +57,6 @@ namespace GraphQL.Relay.Types
             };
         }
 
-        internal static object ToConnection(object values, ResolveConnectionContext<object> context)
-        {
-            throw new NotImplementedException();
-        }
-
         public static string CursorForObjectInConnection<T>(
             IEnumerable<T> slice,
             T item)

--- a/src/Snowflake.Framework.Remoting/GraphQL/Connections/ConnectionUtils.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/Connections/ConnectionUtils.cs
@@ -33,10 +33,12 @@ namespace GraphQL.Relay.Types
                 sliceStartIndex,
                 totalCount);
 
+            int startOffset = metrics.StartOffset;
+
             var edges = metrics.Slice.Select((item, i) => new Edge<TSource>
                 {
                     Node = item,
-                    Cursor = OffsetToCursor(metrics.StartOffset + i),
+                    Cursor = OffsetToCursor(startOffset + i),
                 })
                 .ToList();
 

--- a/src/Snowflake.Framework.Remoting/GraphQL/Connections/EnumerableExtensions.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/Connections/EnumerableExtensions.cs
@@ -10,9 +10,7 @@ namespace GraphQL.Relay.Utilities
         public static IEnumerable<T> Slice<T>(this IEnumerable<T> collection, int start, int end)
         {
             int index = 0;
-            int count = 0;
-
-            count = collection.Count();
+            int count = collection.Count();
 
             // Get start/end indexes, negative numbers start at the end of the collection.
             if (start < 0)

--- a/src/Snowflake.Framework.Remoting/GraphQL/IGraphQLRootSchema.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/IGraphQLRootSchema.cs
@@ -6,8 +6,15 @@ using Snowflake.Framework.Remoting.GraphQL.Query;
 
 namespace Snowflake.Framework.Remoting.GraphQL
 {
+    /// <summary>
+    /// Provides access to the GraphQL root schema.
+    /// </summary>
     public interface IGraphQLService
     {
+        /// <summary>
+        /// Registers a <see cref="QueryBuilder"/> into the root schema.
+        /// </summary>
+        /// <param name="queries">The <see cref="QueryBuilder"/> instance implements the queries.</param>
         void Register(QueryBuilder queries);
     }
 }

--- a/src/Snowflake.Framework.Remoting/GraphQL/Query/QueryBuilder.Framework.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/Query/QueryBuilder.Framework.cs
@@ -14,6 +14,18 @@ using Snowflake.Framework.Remoting.GraphQL.Attributes;
 
 namespace Snowflake.Framework.Remoting.GraphQL.Query
 {
+    /// <summary>
+    /// <para>
+    /// A class that provides GraphQL Schema access through <see cref="IGraphQLService.Register(QueryBuilder)"/> must
+    /// inherit from <see cref="QueryBuilder"/>. While no extra properties are made visible, <see cref="QueryBuilder"/>
+    /// uses some behind-the-scenes reflection access to rewrite properly marked methods of the inheriting class into
+    /// GraphQL-accessible functions.
+    /// </para>
+    /// <para>
+    /// See <see cref="FieldAttribute"/>, <see cref="ConnectionAttribute"/>, and <see cref="MutationAttribute"/> for
+    /// how to mark a method as a GraphQL query.
+    /// </para>
+    /// </summary>
     public abstract partial class QueryBuilder
     {
         private static MethodInfo ConnectionMaker { get; }

--- a/src/Snowflake.Framework.Remoting/GraphQL/Query/QueryBuilder.cs
+++ b/src/Snowflake.Framework.Remoting/GraphQL/Query/QueryBuilder.cs
@@ -2,9 +2,19 @@
 using System.Collections.Generic;
 using System.Text;
 using GraphQL.Types;
+using Snowflake.Framework.Remoting.GraphQL.Attributes;
 
 namespace Snowflake.Framework.Remoting.GraphQL.Query
 {
+    /// <summary>
+    /// A class that provides GraphQL Schema access through <see cref="IGraphQLService.Register(QueryBuilder)"/> must
+    /// inherit from <see cref="QueryBuilder"/>. While no extra properties are made visible, <see cref="QueryBuilder"/>
+    /// uses some behind-the-scenes reflection access to rewrite properly marked methods of the inheriting class into
+    /// GraphQL-accessible functions.
+    /// <br/>
+    /// See <see cref="FieldAttribute"/>, <see cref="ConnectionAttribute"/>, and <see cref="MutationAttribute"/> for
+    /// how to mark a method as a GraphQL query.
+    /// </summary>
     public abstract partial class QueryBuilder
     {
         /// <summary>

--- a/src/Snowflake.Framework.Remoting/Kestrel/IKestrelServerMiddlewareProvider.cs
+++ b/src/Snowflake.Framework.Remoting/Kestrel/IKestrelServerMiddlewareProvider.cs
@@ -3,13 +3,31 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Snowflake.Loader;
 
 namespace Snowflake.Framework.Remoting.Kestrel
 {
+    /// <summary>
+    /// Provides the implementation for a Kestrel middleware.
+    /// <para>
+    /// Since Kestrel is bootstraped by ASP.NET Core, it uses it's own dependency injection container 
+    /// (namely <see cref="IServiceCollection"/>), instead of Snowflake's native <see cref="Snowflake.Services.IServiceContainer"/>.
+    /// Implementing this interface is akin to implementing <see cref="IComposable"/>, but specifically to extend the integrated Kestrel 
+    /// web server.
+    /// </para>
+    /// </summary>
     public interface IKestrelServerMiddlewareProvider
     {
+        /// <summary>
+        /// Use this method to add services to the container that is used by the Kestrel server.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> used by the Kestrel server.</param>
         void ConfigureServices(IServiceCollection services);
 
+        /// <summary>
+        /// Use this method to configure the HTTP request pipeline in Kestrel.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> used by the Kestrel server.</param>
         void Configure(IApplicationBuilder app);
     }
 }

--- a/src/Snowflake.Framework.Remoting/Kestrel/IKestrelWebServerService.cs
+++ b/src/Snowflake.Framework.Remoting/Kestrel/IKestrelWebServerService.cs
@@ -1,9 +1,20 @@
-﻿using System.Threading.Tasks;
+﻿using Snowflake.Loader;
+using System.Threading.Tasks;
 
 namespace Snowflake.Framework.Remoting.Kestrel
 {
+    /// <summary>
+    /// Provides middleware access to the Kestrel remoting server.
+    /// </summary>
     public interface IKestrelWebServerService
     {
+        /// <summary>
+        /// Registers a Kestrel middleware.
+        /// Kestrel middleware can only be registered within <see cref="IComposable.Compose(IModule, IServiceRepository)"/>.
+        /// Once assembly composition finishes, middleware can no longer be added.
+        /// </summary>
+        /// <typeparam name="T">The type of the class that implements the middleware.</typeparam>
+        /// <param name="kestrelServerMiddleware">The middleware to register to the Kestrel server.</param>
         void AddService<T>(T kestrelServerMiddleware) where T : IKestrelServerMiddlewareProvider;
     }
 }

--- a/src/Snowflake.Framework.Remoting/Snowflake.Framework.Remoting.csproj
+++ b/src/Snowflake.Framework.Remoting/Snowflake.Framework.Remoting.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <_SnowflakeUseDevelopmentSDK>true</_SnowflakeUseDevelopmentSDK>
-
+    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Snowflake.Framework.Services/AssemblyLoader/AssemblyComposer.cs
+++ b/src/Snowflake.Framework.Services/AssemblyLoader/AssemblyComposer.cs
@@ -78,7 +78,7 @@ namespace Snowflake.Services.AssemblyLoader
                         try
                         {
                             this.logger.Info(
-                                $"Composing {uncomposed.composable.GetType().Name} with services {string.Join(" ", uncomposed.services)}");
+                                $"Composing {uncomposed.composable.GetType().Name} with services: {Environment.NewLine}\t\t\t\t{string.Join($"{Environment.NewLine}\t\t\t\t", uncomposed.services)}");
                             this.ComposeContainer(uncomposed.module, uncomposed.composable, uncomposed.services);
                             this.logger.Info($"Finished composing {uncomposed.composable.GetType().Name}");
                         }

--- a/src/Snowflake.Framework.Services/AssemblyLoader/AssemblyModuleLoadContext.cs
+++ b/src/Snowflake.Framework.Services/AssemblyLoader/AssemblyModuleLoadContext.cs
@@ -38,12 +38,11 @@ namespace Snowflake.Services.AssemblyLoader
         /// <inheritdoc/>
         protected override Assembly Load(AssemblyName assemblyName)
         {
-            logger.Info($"Attempting to load {assemblyName.Name}");
             if (assemblyName.GetPublicKeyToken().Length == 0 &&
                 unsignedAssemblies.ContainsKey((assemblyName.Name, assemblyName.Version)))
             {
                 logger.Warn(
-                    $"Resolving {assemblyName.Name} version {assemblyName.Version} from unsigned assembly cache.");
+                    $"Resolving {assemblyName.Name} v{assemblyName.Version} from unsigned assembly cache.");
                 return AssemblyModuleLoadContext.unsignedAssemblies[(assemblyName.Name, assemblyName.Version)];
             }
 
@@ -54,7 +53,6 @@ namespace Snowflake.Services.AssemblyLoader
             if (assemblyName.Name == "Snowflake.Framework.Primitives")
             {
                 Version supportedVersion = typeof(IServiceContainer).GetTypeInfo().Assembly.GetName().Version;
-                this.logger.Info($"Found Snowflake Framework Version {assemblyName.Version}");
                 if (assemblyName.Version.Major != supportedVersion.Major)
                 {
                     // todo: more robust version check
@@ -68,7 +66,7 @@ namespace Snowflake.Services.AssemblyLoader
             if (runtimeLibs.Select(l => l.Name.ToLower()).Contains(assemblyName.Name.ToLower()))
             {
                 logger.Info(
-                    $"Attempting to resolve {assemblyName.Name} version {assemblyName.Version} from runtime...");
+                    $"Resolving {assemblyName.Name} v{assemblyName.Version} from runtime.");
                 try
                 {
                     return Assembly.Load(assemblyName);
@@ -114,7 +112,7 @@ namespace Snowflake.Services.AssemblyLoader
                 }
                 else
                 {
-                    logger.Info($"Loading {assemblyName.Name} from GAC!");
+                    logger.Info($"Loading {assemblyName.Name} from GAC.");
                     return Assembly.Load(assemblyName);
                 }
             }

--- a/src/Snowflake.Framework.Services/Logging/NLogLogger.cs
+++ b/src/Snowflake.Framework.Services/Logging/NLogLogger.cs
@@ -29,7 +29,11 @@ namespace Snowflake.Services.Logging
                 Name = "Console"
             };
             consoleTarget.UseDefaultRowHighlightingRules = false;
-
+            consoleTarget.WordHighlightingRules.Add(new ConsoleWordHighlightingRule()
+            {
+                Text = "Snowflake.",
+                ForegroundColor = ConsoleOutputColor.DarkCyan,
+            });
             consoleTarget.WordHighlightingRules.Add(new ConsoleWordHighlightingRule()
             {
                 Regex = @"(?<=^\[\w+\][^w]+)\(\w+\)",

--- a/src/Snowflake.Framework.Services/Logging/NLogLogger.cs
+++ b/src/Snowflake.Framework.Services/Logging/NLogLogger.cs
@@ -11,19 +11,14 @@ namespace Snowflake.Services.Logging
     internal class NlogLogger : Snowflake.Extensibility.ILogger
     {
         private readonly NLog.ILogger baseLogger;
-
-        private static bool isSetup = false;
-
-        private static void Setup()
+        private static readonly ColoredConsoleTarget consoleTarget;
+        private static readonly AsyncTargetWrapper asyncConsoleTarget;
+        private static readonly LoggingConfiguration configuration;
+        static NlogLogger()
         {
-            if (NlogLogger.isSetup)
-            {
-                return;
-            }
-
-            var configuration = new LoggingConfiguration();
-            var consoleTarget = new ColoredConsoleTarget("Console");
-            var asyncConsoleTarget = new AsyncTargetWrapper(consoleTarget, 2400, AsyncTargetWrapperOverflowAction.Grow)
+            NlogLogger.configuration = new LoggingConfiguration();
+            NlogLogger.consoleTarget = new ColoredConsoleTarget("Console");
+            NlogLogger.asyncConsoleTarget = new AsyncTargetWrapper(consoleTarget, 2400, AsyncTargetWrapperOverflowAction.Grow)
             {
                 OptimizeBufferReuse = true,
                 Name = "Console"
@@ -85,7 +80,7 @@ namespace Snowflake.Services.Logging
                 ForegroundColor = ConsoleOutputColor.Yellow,
             });
             consoleTarget.RowHighlightingRules.Add(new ConsoleRowHighlightingRule()
-            { 
+            {
                 Condition = "level == LogLevel.Info",
                 ForegroundColor = ConsoleOutputColor.Gray,
             });
@@ -105,7 +100,6 @@ namespace Snowflake.Services.Logging
             configuration.AddRule(NLog.LogLevel.Trace, NLog.LogLevel.Fatal, asyncConsoleTarget);
             configuration.AddTarget(asyncConsoleTarget);
             LogManager.Configuration = configuration;
-            NlogLogger.isSetup = true;
         }
 
         internal NlogLogger(NLog.ILogger baseLogger)
@@ -115,7 +109,6 @@ namespace Snowflake.Services.Logging
 
         public NlogLogger(string loggerName)
         {
-            NlogLogger.Setup();
             this.baseLogger = LogManager.GetLogger(loggerName);
         }
 

--- a/src/Snowflake.Framework.Services/ServiceContainer.cs
+++ b/src/Snowflake.Framework.Services/ServiceContainer.cs
@@ -17,7 +17,7 @@ using Zio.FileSystems;
 namespace Snowflake.Services
 {
     /// <inheritdoc />
-    public class ServiceContainer : IServiceContainer
+    internal class ServiceContainer : IServiceContainer
     {
         #region Loaded Objects
 
@@ -32,7 +32,7 @@ namespace Snowflake.Services
         bool disposed;
 
         /// <inheritdoc />
-        public ServiceContainer(string appDataDirectory)
+        public ServiceContainer(string appDataDirectory, string kestrelHostname)
         {
             this.AppDataDirectory = appDataDirectory;
             var directoryProvider = new ContentDirectoryProvider(this.AppDataDirectory);
@@ -41,7 +41,7 @@ namespace Snowflake.Services
             this.RegisterService<ILogProvider>(new LogProvider());
             this.RegisterService<IModuleEnumerator>(new ModuleEnumerator(appDataDirectory));
             this.RegisterService<IKestrelWebServerService>(new KestrelServerService(appDataDirectory,
-                "http://localhost:9797",
+                kestrelHostname,
                 this.Get<ILogProvider>().GetLogger("kestrel")));
 
             this.RegisterGraphQLRootSchema();

--- a/src/Snowflake.Framework.Services/ServiceContainer.cs
+++ b/src/Snowflake.Framework.Services/ServiceContainer.cs
@@ -63,10 +63,9 @@ namespace Snowflake.Services
         /// <inheritdoc/>
         public void RegisterService<T>(T serviceObject)
         {
-            // todo: check for same name
             if (this.serviceContainer.ContainsKey(typeof(T)))
             {
-                return; // todo throw exception
+                throw new ArgumentException($"A service of type {typeof(T).AssemblyQualifiedName} already exists!");
             }
 
             this.serviceContainer.Add(typeof(T), serviceObject);

--- a/src/Snowflake.Framework.Services/ServiceRegistrationProvider.cs
+++ b/src/Snowflake.Framework.Services/ServiceRegistrationProvider.cs
@@ -20,7 +20,7 @@ namespace Snowflake.Services
             if (typeof(T).Assembly == serviceObject.GetType().Assembly)
             {
                 throw new InvalidOperationException(
-                    "Can not register a service who's implementation and interface reside in the same assembly!");
+                    "Unable to register a service whose implementation and interface reside in the same assembly!");
             }
 
             this.coreService.RegisterService(serviceObject);

--- a/src/Snowflake.Framework.Tests/FileSystem/DirectoryTests.cs
+++ b/src/Snowflake.Framework.Tests/FileSystem/DirectoryTests.cs
@@ -121,7 +121,7 @@ namespace Snowflake.Filesystem.Tests
             var fs = new PhysicalFileSystem();
             var temp = Path.GetTempPath();
             var pfs = fs.GetOrCreateSubFileSystem(fs.ConvertPathFromInternal(temp));
-            var dir = new FS.Directory("test", pfs, pfs.GetDirectoryEntry("/"));
+            var dir = new FS.Directory("testrr", pfs, pfs.GetDirectoryEntry("/"));
             var file = dir.OpenFile("test.txt");
             Assert.True(dir.ContainsFile(".manifest"));
             Assert.Equal(file.FileGuid, dir.RetrieveManifestRecord(dir.ThisDirectory.Path / Path.GetFileName("test.txt"), false).guid);

--- a/src/Snowflake.Framework.Tests/Loader/AssemblyComposerTests.cs
+++ b/src/Snowflake.Framework.Tests/Loader/AssemblyComposerTests.cs
@@ -74,7 +74,7 @@ namespace Snowflake.Loader.Tests
             ZipArchive archive = new ZipArchive(composableAssemblyZipStream);
 
             archive.ExtractToDirectory(moduleDirectory.CreateSubdirectory("Snowflake.Framework.Tests").FullName);
-            var container = new ServiceContainer(appDataDirectory.FullName, "https://localhost:9797");
+            var container = new ServiceContainer(appDataDirectory.FullName, "http://localhost:9797");
 
             var module = container.Get<IModuleEnumerator>()
                 .Modules.FirstOrDefault(m => m.Entry == "Snowflake.Framework.Tests.InvalidComposable.dll");

--- a/src/Snowflake.Framework.Tests/Loader/AssemblyComposerTests.cs
+++ b/src/Snowflake.Framework.Tests/Loader/AssemblyComposerTests.cs
@@ -29,7 +29,7 @@ namespace Snowflake.Loader.Tests
             ZipArchive archive = new ZipArchive(composableAssemblyZipStream);
 
             archive.ExtractToDirectory(moduleDirectory.CreateSubdirectory("Snowflake.Framework.Tests").FullName);
-            var container = new ServiceContainer(appDataDirectory.FullName);
+            var container = new ServiceContainer(appDataDirectory.FullName, "https://localhost:9797");
 
             Assert.Contains(container.Get<IModuleEnumerator>()
                 .Modules, m => m.Entry == "Snowflake.Framework.Tests.DummyComposable.dll");
@@ -52,7 +52,7 @@ namespace Snowflake.Loader.Tests
             ZipArchive archive = new ZipArchive(composableAssemblyZipStream);
 
             archive.ExtractToDirectory(moduleDirectory.CreateSubdirectory("Snowflake.Framework.Tests").FullName);
-            var container = new ServiceContainer(appDataDirectory.FullName);
+            var container = new ServiceContainer(appDataDirectory.FullName, "https://localhost:9797");
 
             Assert.Contains(container.Get<IModuleEnumerator>()
                 .Modules, m => m.Entry == "Snowflake.Framework.Tests.InvalidComposable.dll");
@@ -74,7 +74,7 @@ namespace Snowflake.Loader.Tests
             ZipArchive archive = new ZipArchive(composableAssemblyZipStream);
 
             archive.ExtractToDirectory(moduleDirectory.CreateSubdirectory("Snowflake.Framework.Tests").FullName);
-            var container = new ServiceContainer(appDataDirectory.FullName);
+            var container = new ServiceContainer(appDataDirectory.FullName, "https://localhost:9797");
 
             var module = container.Get<IModuleEnumerator>()
                 .Modules.FirstOrDefault(m => m.Entry == "Snowflake.Framework.Tests.InvalidComposable.dll");

--- a/src/Snowflake.Framework.Tests/Services/ServiceContainerTests.cs
+++ b/src/Snowflake.Framework.Tests/Services/ServiceContainerTests.cs
@@ -15,7 +15,7 @@ namespace Snowflake.Services.Tests
         {
             var appDataDirectory = new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Guid.NewGuid().ToString());
-            var container = new ServiceContainer(appDataDirectory.FullName);
+            var container = new ServiceContainer(appDataDirectory.FullName, "https://localhost:9797");
         }
 
         [Fact]
@@ -23,7 +23,7 @@ namespace Snowflake.Services.Tests
         {
             var appDataDirectory = new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Guid.NewGuid().ToString());
-            var container = new ServiceContainer(appDataDirectory.FullName);
+            var container = new ServiceContainer(appDataDirectory.FullName, "https://localhost:9797");
             Assert.NotNull(container.Get<IServiceRegistrationProvider>());
             Assert.NotNull(container.Get<IContentDirectoryProvider>());
             Assert.NotNull(container.Get<ILogProvider>());
@@ -36,7 +36,7 @@ namespace Snowflake.Services.Tests
         {
             var appDataDirectory = new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Guid.NewGuid().ToString());
-            var container = new ServiceContainer(appDataDirectory.FullName);
+            var container = new ServiceContainer(appDataDirectory.FullName, "https://localhost:9797");
             IDummyComposable dummy = new DummyService();
             container.RegisterService(dummy);
             Assert.Equal(dummy, container.Get<IDummyComposable>());

--- a/src/Snowflake.Framework.Tests/Services/ServiceContainerTests.cs
+++ b/src/Snowflake.Framework.Tests/Services/ServiceContainerTests.cs
@@ -15,7 +15,7 @@ namespace Snowflake.Services.Tests
         {
             var appDataDirectory = new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Guid.NewGuid().ToString());
-            var container = new ServiceContainer(appDataDirectory.FullName, "https://localhost:9797");
+            var container = new ServiceContainer(appDataDirectory.FullName, "http://localhost:9797");
         }
 
         [Fact]
@@ -23,7 +23,7 @@ namespace Snowflake.Services.Tests
         {
             var appDataDirectory = new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Guid.NewGuid().ToString());
-            var container = new ServiceContainer(appDataDirectory.FullName, "https://localhost:9797");
+            var container = new ServiceContainer(appDataDirectory.FullName, "http://localhost:9797");
             Assert.NotNull(container.Get<IServiceRegistrationProvider>());
             Assert.NotNull(container.Get<IContentDirectoryProvider>());
             Assert.NotNull(container.Get<ILogProvider>());
@@ -36,7 +36,7 @@ namespace Snowflake.Services.Tests
         {
             var appDataDirectory = new DirectoryInfo(Path.GetTempPath())
                 .CreateSubdirectory(Guid.NewGuid().ToString());
-            var container = new ServiceContainer(appDataDirectory.FullName, "https://localhost:9797");
+            var container = new ServiceContainer(appDataDirectory.FullName, "http://localhost:9797");
             IDummyComposable dummy = new DummyService();
             container.RegisterService(dummy);
             Assert.Equal(dummy, container.Get<IDummyComposable>());

--- a/src/Snowflake.Framework/Extensibility/PluginCollection.cs
+++ b/src/Snowflake.Framework/Extensibility/PluginCollection.cs
@@ -7,7 +7,7 @@ using Snowflake.Services;
 namespace Snowflake.Extensibility
 {
     public class PluginCollection<T> : IPluginCollection<T>
-        where T : IPlugin
+        where T : class, IPlugin
     {
         private IPluginManager PluginManager { get; }
 
@@ -16,7 +16,7 @@ namespace Snowflake.Extensibility
             this.PluginManager = manager;
         }
 
-        public T this[string pluginName] => this.PluginManager.Get<T>(pluginName);
+        public T? this[string pluginName] => this.PluginManager.Get<T>(pluginName);
 
         public IEnumerator<T> GetEnumerator() => this.PluginManager.Get<T>().GetEnumerator();
 

--- a/src/Snowflake.Framework/Input/Controller/Mapped/ControllerElementMappings.cs
+++ b/src/Snowflake.Framework/Input/Controller/Mapped/ControllerElementMappings.cs
@@ -47,6 +47,15 @@ namespace Snowflake.Input.Controller.Mapped
 
         private readonly Dictionary<ControllerElement, MappedControllerElement> controllerElements;
 
+        /// <summary>
+        /// Initializes a <see cref="ControllerElementMappings"/> from an <see cref="IDeviceLayoutMapping"/>,
+        /// that includes all mappings from the default layout.
+        /// </summary>
+        /// <param name="deviceName">The name of the physical device for this set of mappings.</param>
+        /// <param name="controllerId">The Stone <see cref="ControllerId"/> this mapping is intended for.</param>
+        /// <param name="driver">The <see cref="InputDriverType"/> of the device instance for this set of mappings.</param>
+        /// <param name="vendor">The vendor ID of the physical device for this set of mappings.</param>
+        /// <param name="mapping">The device layout mapping provided by the device enumerator.</param>
         public ControllerElementMappings(string deviceName,
             ControllerId controllerId, InputDriverType driver, int vendor,
             IDeviceLayoutMapping mapping)
@@ -55,6 +64,27 @@ namespace Snowflake.Input.Controller.Mapped
             foreach (var controllerElement in mapping)
             {
                 this.Add(controllerElement);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a<see cref= "ControllerElementMappings" /> from an <see cref="IDeviceLayoutMapping"/>,
+        /// that includes only mappings that are assignable to the provided layout.
+        /// </summary>
+        /// <param name="deviceName">The name of the physical device for this set of mappings.</param>
+        /// <param name="controller">The controller layout to assign device mappings to.</param>
+        /// <param name="driver">The <see cref="InputDriverType"/> of the device instance for this set of mappings.</param>
+        /// <param name="vendor">The vendor ID of the physical device for this set of mappings.</param>
+        /// <param name="mapping">The device layout mapping provided by the device enumerator.</param>
+        public ControllerElementMappings(string deviceName,
+           IControllerLayout controller, InputDriverType driver, int vendor,
+           IDeviceLayoutMapping mapping)
+           : this(deviceName, controller.LayoutId, driver, vendor)
+        {
+            foreach (var (controllerElement, _) in controller.Layout)
+            {
+                if (mapping[controllerElement] == DeviceCapability.None) continue;
+                this.Add(new MappedControllerElement(controllerElement, mapping[controllerElement]));
             }
         }
 

--- a/src/Snowflake.Framework/Model/Database/ControllerElementMappingsStore.cs
+++ b/src/Snowflake.Framework/Model/Database/ControllerElementMappingsStore.cs
@@ -25,6 +25,7 @@ namespace Snowflake.Model.Database
         public void AddMappings(IControllerElementMappings mappings, string profileName)
         {
             using var context = new DatabaseContext(this.Options.Options);
+            // todo: check already exists
             context.ControllerElementMappings.Add(mappings.AsModel(profileName));
             context.SaveChanges();
         }

--- a/src/Snowflake.Framework/Model/Database/Models/PortDeviceEntryModel.cs
+++ b/src/Snowflake.Framework/Model/Database/Models/PortDeviceEntryModel.cs
@@ -4,8 +4,6 @@ using Snowflake.Input.Device;
 using Snowflake.Model.Game;
 using Snowflake.Orchestration.Extensibility;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Snowflake.Model.Database.Models
 {

--- a/src/Snowflake.Framework/Snowflake.Framework.xml
+++ b/src/Snowflake.Framework/Snowflake.Framework.xml
@@ -881,6 +881,28 @@
         <member name="P:Snowflake.Input.Controller.Mapped.ControllerElementMappings.ControllerId">
             <inheritdoc/>
         </member>
+        <member name="M:Snowflake.Input.Controller.Mapped.ControllerElementMappings.#ctor(System.String,Snowflake.Input.Controller.ControllerId,Snowflake.Input.Device.InputDriverType,System.Int32,Snowflake.Input.Device.IDeviceLayoutMapping)">
+            <summary>
+            Initializes a <see cref="T:Snowflake.Input.Controller.Mapped.ControllerElementMappings"/> from an <see cref="T:Snowflake.Input.Device.IDeviceLayoutMapping"/>,
+            that includes all mappings from the default layout.
+            </summary>
+            <param name="deviceName">The name of the physical device for this set of mappings.</param>
+            <param name="controllerId">The Stone <see cref="P:Snowflake.Input.Controller.Mapped.ControllerElementMappings.ControllerId"/> this mapping is intended for.</param>
+            <param name="driver">The <see cref="T:Snowflake.Input.Device.InputDriverType"/> of the device instance for this set of mappings.</param>
+            <param name="vendor">The vendor ID of the physical device for this set of mappings.</param>
+            <param name="mapping">The device layout mapping provided by the device enumerator.</param>
+        </member>
+        <member name="M:Snowflake.Input.Controller.Mapped.ControllerElementMappings.#ctor(System.String,Snowflake.Input.Controller.IControllerLayout,Snowflake.Input.Device.InputDriverType,System.Int32,Snowflake.Input.Device.IDeviceLayoutMapping)">
+            <summary>
+            Initializes a<see cref= "T:Snowflake.Input.Controller.Mapped.ControllerElementMappings" /> from an <see cref="T:Snowflake.Input.Device.IDeviceLayoutMapping"/>,
+            that includes only mappings that are assignable to the provided layout.
+            </summary>
+            <param name="deviceName">The name of the physical device for this set of mappings.</param>
+            <param name="controller">The controller layout to assign device mappings to.</param>
+            <param name="driver">The <see cref="T:Snowflake.Input.Device.InputDriverType"/> of the device instance for this set of mappings.</param>
+            <param name="vendor">The vendor ID of the physical device for this set of mappings.</param>
+            <param name="mapping">The device layout mapping provided by the device enumerator.</param>
+        </member>
         <member name="M:Snowflake.Input.Device.DeviceCapabilityExtensions.GetClass(Snowflake.Input.Device.DeviceCapability)">
             <summary>
             Gets the capability class of this <see cref="T:Snowflake.Input.Device.DeviceCapability"/>

--- a/src/Snowflake.Plugin.Scraping.GiantBomb/GiantBombScraper.cs
+++ b/src/Snowflake.Plugin.Scraping.GiantBomb/GiantBombScraper.cs
@@ -47,7 +47,7 @@ namespace Snowflake.Plugin.Scraping.GiantBomb
             {"SEGA_GG", 5},
         };
 
-        private static IDictionary<string, SortDirection> defaultSort = new Dictionary<string, SortDirection>
+        private static readonly IDictionary<string, SortDirection> defaultSort = new Dictionary<string, SortDirection>
         {
             {"name", SortDirection.Ascending }
         };

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Containers/GameQueryContainer.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Containers/GameQueryContainer.cs
@@ -14,7 +14,6 @@ using Snowflake.Scraping;
 using Snowflake.Scraping.Extensibility;
 using Snowflake.Services;
 using Snowflake.Support.GraphQLFrameworkQueries.Queries;
-using Snowflake.Support.GraphQLFrameworkQueries.Queries;
 
 namespace Snowflake.Support.GraphQLFrameworkQueries.Containers
 {

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Containers/GameQueryContainer.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Containers/GameQueryContainer.cs
@@ -22,7 +22,6 @@ namespace Snowflake.Support.GraphQLFrameworkQueries.Containers
     {
         /// <inheritdoc/>
         [ImportService(typeof(IPluginManager))]
-        [ImportService(typeof(IStoneProvider))]
         [ImportService(typeof(IGameLibrary))]
         [ImportService(typeof(IGraphQLService))]
         [ImportService(typeof(ILogProvider))]
@@ -30,12 +29,11 @@ namespace Snowflake.Support.GraphQLFrameworkQueries.Containers
         {
             var plugin = coreInstance.Get<IPluginManager>();
 
-            var stone = coreInstance.Get<IStoneProvider>();
             var games = coreInstance.Get<IGameLibrary>();
             var rootSchema = coreInstance.Get<IGraphQLService>();
 
             var gameQuery = new GameQueryBuilder(plugin.GetCollection<IGameInstaller>(),
-                stone, new AsyncJobQueue<TaskResult<IFile>>(), games);
+                new AsyncJobQueue<TaskResult<IFile>>(), games);
             rootSchema.Register(gameQuery);
             var logger = coreInstance.Get<ILogProvider>().GetLogger("graphql");
             logger.Info("Registered Game GraphQL Queries.");

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Queries/EmulationQueryBuilder.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Queries/EmulationQueryBuilder.cs
@@ -1,86 +1,44 @@
-﻿//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Text;
-//using System.Threading.Tasks;
-//using GraphQL.Types;
-//using Snowflake.Execution.Extensibility;
-//using Snowflake.Extensibility;
-//using Snowflake.Framework.Remoting.GraphQL.Attributes;
-//using Snowflake.Framework.Remoting.GraphQL.Query;
-//using Snowflake.Model.Game;
-//using Snowflake.Services;
-//using Snowflake.Support.GraphQLFrameworkQueries.Inputs.EmulatedController;
-//using Snowflake.Support.GraphQLFrameworkQueries.Types.Execution;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GraphQL.Types;
+using Snowflake.Extensibility;
+using Snowflake.Framework.Remoting.GraphQL.Attributes;
+using Snowflake.Framework.Remoting.GraphQL.Query;
+using Snowflake.Model.Game;
+using Snowflake.Orchestration.Extensibility;
+using Snowflake.Services;
 
-//namespace Snowflake.Support.GraphQLFrameworkQueries.Queries
-//{
-//    public class EmulationQueryBuilder : QueryBuilder
-//    {
-//        public IPluginCollection<IEmulator> Emulators { get; }
-//        public IStoneProvider Stone { get; }
-//        public IGameLibrary GameLibrary { get; }
-//        public InputQueryBuilder InputQueryApi { get; }
-//        public ControllerLayoutQueryBuilder ControllerQueryApi { get; }
+namespace Snowflake.Support.GraphQLFrameworkQueries.Queries
+{
+    public class EmulationQueryBuilder : QueryBuilder
+    {
+        public IPluginCollection<IEmulatorOrchestrator> Orchestrators { get; }
+        public IStoneProvider Stone { get; }
+        public IGameLibrary GameLibrary { get; }
+        public InputQueryBuilder InputQueryApi { get; }
+        public ControllerLayoutQueryBuilder ControllerQueryApi { get; }
 
-//        public EmulationQueryBuilder(IPluginCollection<IEmulator> emulators,
-//            IStoneProvider stone,
-//            IGameLibrary library,
-//            InputQueryBuilder inputQueryBuilder,
-//            ControllerLayoutQueryBuilder controllerLayoutQueryBuilder)
-//        {
-//            this.Emulators = emulators;
-//            this.Stone = stone;
-//            this.InputQueryApi = inputQueryBuilder;
-//            this.ControllerQueryApi = controllerLayoutQueryBuilder;
-//            this.GameLibrary = library;
-//        }
+        public EmulationQueryBuilder(IPluginCollection<IEmulatorOrchestrator> orchestrators,
+            IStoneProvider stone,
+            IGameLibrary library,
+            InputQueryBuilder inputQueryBuilder,
+            ControllerLayoutQueryBuilder controllerLayoutQueryBuilder)
+        {
+            this.Orchestrators = orchestrators;
+            this.Stone = stone;
+            this.InputQueryApi = inputQueryBuilder;
+            this.ControllerQueryApi = controllerLayoutQueryBuilder;
+            this.GameLibrary = library;
+        }
 
-//        [Field("testEmuTask", "test", typeof(EmulatorTaskResultGraphType))]
-//        [Parameter(typeof(IList<EmulatedControllerInputObject>), typeof(ListGraphType<EmulatedControllerInputType>),
-//            "controllers", "The emulated controller input")]
-//        public async Task<IEmulatorTaskResult> TestTask(IList<EmulatedControllerInputObject> controllers)
-//        {
-//            //var emu = this.Emulators.First();
-//            //var game = new GameRecord(this.Stone.Platforms["NINTENDO_SNES"], "TestGame");
-//            //var saveLocation = await this.SaveLocationProvider.CreateSaveLocationAsync(game, "sram");
-//            //var task = emu.CreateTask(game, saveLocation, controllers.Select(c => this.ParseController(c)).ToList());
-//            //return await emu.Runner.ExecuteEmulationAsync(task);
-//            return null;
-//        }
-
-//        [Field("launchEmulatorTask", "Launches an emulator task", typeof(EmulatorTaskResultGraphType))]
-//        [Parameter(typeof(IList<EmulatedControllerInputObject>), typeof(ListGraphType<EmulatedControllerInputType>),
-//            "controllers", "The emulated controller input")]
-//        [Parameter(typeof(string), typeof(StringGraphType), "emulator", "The name of the emulator to launch.")]
-//        [Parameter(typeof(Guid), typeof(GuidGraphType), "gameGuid", "The GUID of the game to launch.")]
-//        public async Task<IEmulatorTaskResult> LaunchEmulatorTask(
-//            string emulator,
-//            Guid gameGuid,
-//            IList<EmulatedControllerInputObject> controllers)
-//        {
-//            //var emu = this.Emulators.Where(e => e.Name.Equals(emulator, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-//            //var game = this.GameLibrary.Get(gameGuid);
-//            //var saveLocation = await this.SaveLocationProvider.CreateSaveLocationAsync(game, emu.Properties.SaveFormat);
-//            //var task = emu.CreateTask(game, saveLocation, controllers.Select(c => this.ParseController(c)).ToList());
-//            //return await emu.Runner.ExecuteEmulationAsync(task);
-//            return null;
-//        }
-
-//        [Field("emulatedController", "Gets the emulated controller object", typeof(EmulatedControllerGraphType))]
-//        [Parameter(typeof(EmulatedControllerInputObject), typeof(EmulatedControllerInputType), "input",
-//            "The emulated controller input")]
-//        public IEmulatedController ParseController(EmulatedControllerInputObject input)
-//        {
-//            //var controller = this.ControllerQueryApi.GetControllerLayout(input.TargetLayout);
-//            //var device = this.InputQueryApi.GetAllInputDevices()
-//            //    .Where(i => i.DeviceApi == input.InputDevice.DeviceApi
-//            //                && i.DeviceId == input.InputDevice.DeviceId
-//            //                && i.DeviceIndex == input.InputDevice.DeviceIndex)
-//            //    .FirstOrDefault();
-//            //var mapping = this.InputQueryApi.GetProfile(input.TargetLayout, input.InputDevice.DeviceId,
-//            //    input.ControllerProfile);
-//            //return new EmulatedController(input.PortIndex, device, controller, mapping);
-//        }
-//    }
-//}
+        public Guid CreateGameEmulationInstance(string emulatorName)
+        {
+            var orchestrator = this.Orchestrators[emulatorName];
+            return new Guid();
+        }
+        
+    }
+}

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Queries/InputQueryBuilder.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Queries/InputQueryBuilder.cs
@@ -12,7 +12,6 @@ using Snowflake.Input.Controller.Mapped;
 using Snowflake.Input.Device;
 using Snowflake.Services;
 using Snowflake.Support.GraphQLFrameworkQueries.Inputs.MappedControllerElement;
-using Snowflake.Support.GraphQLFrameworkQueries.Types.Configuration;
 using Snowflake.Support.GraphQLFrameworkQueries.Types.InputDevice;
 using Snowflake.Support.GraphQLFrameworkQueries.Types.InputDevice.Mapped;
 
@@ -64,7 +63,6 @@ namespace Snowflake.Support.GraphQLFrameworkQueries.Queries
             return this.MappedElementStore.GetMappings(controllerId, deviceName, vendorId);
         }
 
-        // todo: make this a mutation input object.
         [Field("defaultLayout",
             "Gets the default mapping between Stone controller IDs and the provided device.",
             typeof(ListGraphType<MappedControllerElementGraphType>))]
@@ -89,11 +87,12 @@ namespace Snowflake.Support.GraphQLFrameworkQueries.Queries
                 .FirstOrDefault(d => d.InstanceGuid == input.InstanceGuid);
             var instance = device?.Instances
                 .FirstOrDefault(i => i.Driver == input.InputDriver);
-
+            this.StoneProvider.Controllers.TryGetValue(input.ControllerId, out var controllerLayout);
             // todo : throw error here?
             if (instance == null) return null;
+            if (controllerLayout == null) return null;
 
-            var defaults = new ControllerElementMappings(device.DeviceName, input.ControllerId,
+            var defaults = new ControllerElementMappings(device.DeviceName, controllerLayout,
                 input.InputDriver, device.VendorID, instance.DefaultLayout);
             this.MappedElementStore.AddMappings(defaults, input.ProfileName);
             return this.MappedElementStore.GetMappings(input.ControllerId, instance.Driver,

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Queries/InputQueryBuilder.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Queries/InputQueryBuilder.cs
@@ -87,12 +87,11 @@ namespace Snowflake.Support.GraphQLFrameworkQueries.Queries
                 .FirstOrDefault(d => d.InstanceGuid == input.InstanceGuid);
             var instance = device?.Instances
                 .FirstOrDefault(i => i.Driver == input.InputDriver);
-            this.StoneProvider.Controllers.TryGetValue(input.ControllerId, out var controllerLayout);
             // todo : throw error here?
             if (instance == null) return null;
-            if (controllerLayout == null) return null;
+            if (!this.StoneProvider.Controllers.TryGetValue(input.ControllerId, out var controllerLayout)) return null;
 
-            var defaults = new ControllerElementMappings(device.DeviceName, controllerLayout,
+            var defaults = new ControllerElementMappings(device!.DeviceName, controllerLayout,
                 input.InputDriver, device.VendorID, instance.DefaultLayout);
             this.MappedElementStore.AddMappings(defaults, input.ProfileName);
             return this.MappedElementStore.GetMappings(input.ControllerId, instance.Driver,

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Types/Installable/InstallableGraphObject.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Types/Installable/InstallableGraphObject.cs
@@ -1,0 +1,22 @@
+﻿using Snowflake.Installation.Extensibility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Snowflake.Support.GraphQLFrameworkQueries.Types.Installable
+{
+    public class InstallableGraphObject
+    {
+        public InstallableGraphObject(IGameInstaller installer, IInstallable installable)
+        {
+            this.DisplayName = installable.DisplayName;
+            this.Artifacts = installable.Artifacts.Select(a => a.FullName);
+            this.InstallerName = installer.Name;
+        }
+
+        public string DisplayName { get; }
+        public IEnumerable<string> Artifacts { get; }
+        public string InstallerName { get; }
+    }
+}

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Types/Installable/InstallableGraphType.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Types/Installable/InstallableGraphType.cs
@@ -1,0 +1,27 @@
+﻿using GraphQL.Types;
+using Snowflake.Installation.Extensibility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Snowflake.Support.GraphQLFrameworkQueries.Types.Installable
+{
+    public class InstallableGraphType : ObjectGraphType<InstallableGraphObject>
+    {
+        public InstallableGraphType()
+        {
+            Name = "Installable";
+            Description = "A grouping of installable file entries that can be installed as a unit to a Game.";
+            Field<StringGraphType>("displayName",
+                description: "The friendly display name of the installable file.",
+                resolve: o => o.Source.DisplayName);
+            Field<ListGraphType<StringGraphType>>("artifacts",
+               description: "The list of artifacts to be installed.",
+               resolve: o => o.Source.Artifacts);
+            Field<StringGraphType>("installerName",
+                description: "The name of the installer that produced this installable",
+                resolve: o => o.Source.InstallerName);
+        }
+    }
+}

--- a/src/Snowflake.Support.PluginManager/PluginManager.cs
+++ b/src/Snowflake.Support.PluginManager/PluginManager.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Snowflake.Extensibility;
@@ -48,7 +47,7 @@ namespace Snowflake.Support.PluginManager
 
         /// <inheritdoc/>
         public IPluginProvision GetProvision<T>(IModule composableModule)
-            where T : IPlugin
+            where T : class, IPlugin
         {
             var appDataPath = rootFs.ConvertPathFromInternal(this.contentDirectory.ApplicationData.FullName);
 
@@ -102,7 +101,7 @@ namespace Snowflake.Support.PluginManager
 
         /// <inheritdoc/>
         public IEnumerable<T> Get<T>()
-            where T : IPlugin
+            where T : class, IPlugin
         {
             if (this.loadedPlugins.ContainsKey(typeof(T)))
             {
@@ -113,10 +112,11 @@ namespace Snowflake.Support.PluginManager
         }
 
         /// <inheritdoc/>
-        public T Get<T>(string pluginName)
-            where T : IPlugin
+        public T? Get<T>(string pluginName)
+            where T : class, IPlugin
         {
-            return (T) this.loadedPlugins[typeof(T)].FirstOrDefault(p => p.Name == pluginName);
+            if (!this.loadedPlugins.TryGetValue(typeof(T), out var pluginCollection)) return null;
+            return (T?) pluginCollection.FirstOrDefault(p => p.Name == pluginName);
         }
 
         /// <inheritdoc/>
@@ -130,7 +130,7 @@ namespace Snowflake.Support.PluginManager
 
         /// <inheritdoc/>
         public void Register<T>(T plugin)
-            where T : IPlugin
+            where T : class, IPlugin
         {
             if (!this.loadedPlugins.ContainsKey(typeof(T)))
             {
@@ -147,7 +147,7 @@ namespace Snowflake.Support.PluginManager
 
         /// <inheritdoc/>
         public bool IsRegistered<T>(string pluginName)
-            where T : IPlugin
+            where T : class, IPlugin
         {
             return this.Get<T>(pluginName) != null;
         }
@@ -160,7 +160,7 @@ namespace Snowflake.Support.PluginManager
 
         /// <inheritdoc/>
         public IPluginCollection<T> GetCollection<T>()
-            where T : IPlugin
+            where T : class, IPlugin
         {
             return new PluginCollection<T>(this);
         }

--- a/src/Snowflake.Support.PluginManager/Snowflake.Support.PluginManager.csproj
+++ b/src/Snowflake.Support.PluginManager/Snowflake.Support.PluginManager.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>Snowflake.Support.PluginManager</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <_SnowflakeUseDevelopmentSDK>true</_SnowflakeUseDevelopmentSDK>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Snowflake.Support.StoneProvider/Snowflake.Support.StoneProvider.csproj
+++ b/src/Snowflake.Support.StoneProvider/Snowflake.Support.StoneProvider.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiscUtils.Core" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Iso9660" Version="0.15.1-ci0002" />
     <PackageReference Include="MimeMapping" Version="1.0.1.26" />
+    <PackageReference Include="Quamotion.DiscUtils.Core" Version="0.15.4" />
+    <PackageReference Include="Quamotion.DiscUtils.Iso9660" Version="0.15.4" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Implements the following GraphQL endpoints

* `inputDevices` (Already implemented in #513) Enumerates input devices
* `controllerProfile`  (Already implemented in #513) Gets a given controller profile
* `controllerProfiles`  (Already implemented in #513) Gets all controller profiles
* `installables` (Enumerates given installables)

Cleans up the following APIs
* `IServiceRegistrationProvider` now properly throws `ArgumentException` on duplicate registrations.
* `IPluginManager.Register<T>` is now restricted to reference type implementations of `IPlugin`.
* `T? IPluginManager.Get<T>` is now marked as nullable.
* Documentation for Snowflake.Framework.Remoting public APIs.
* Made `ArraySliceMetrics` a struct