### PR TITLE
ConfigurationCollectionStore: Micro-optimization for ConfigurationCollectionStore

### DIFF
--- a/src/Snowflake.Framework.Primitives/Configuration/IConfigurationValueCollection.cs
+++ b/src/Snowflake.Framework.Primitives/Configuration/IConfigurationValueCollection.cs
@@ -17,11 +17,20 @@ namespace Snowflake.Configuration
 
         /// <summary>
         /// Retrieve the value in the collection for the given option within the given section.
+        /// This method retrieves the value in O(1) average time.
         /// </summary>
         /// <param name="descriptor">The descriptor for the section to examine.</param>
         /// <param name="option">The option key within the section of the configuration.</param>
         /// <returns>The configuration value of the provided option.</returns>
         IConfigurationValue? this[IConfigurationSectionDescriptor descriptor, string option] { get; }
+
+        /// <summary>
+        /// Retrieves the value in the collection that has the given GUID, or a 3-tuple of null values if not found.
+        /// This method retrieves the value in O(1) average time.
+        /// </summary>
+        /// <param name="valueGuid">The GUID of the configuration value</param>
+        /// <returns>The value in the collection that has the given GUID, or a 3-tuple of null values if not found.</returns>
+        (string? section, string? option, IConfigurationValue? value) this[Guid valueGuid] { get; }
 
         /// <summary>
         /// Retrieve a read-only view of configuration values for a given configuration section.

--- a/src/Snowflake.Framework.Primitives/Model/Records/File/ImageMetadataKeys.cs
+++ b/src/Snowflake.Framework.Primitives/Model/Records/File/ImageMetadataKeys.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Snowflake.Caching
+namespace Snowflake.Model.Records.File
 {
     /// <summary>
     /// The image metadata key

--- a/src/Snowflake.Framework.Primitives/Model/Records/File/ImageTypes.cs
+++ b/src/Snowflake.Framework.Primitives/Model/Records/File/ImageTypes.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Snowflake.Caching
+namespace Snowflake.Model.Records.File
 {
     /// <summary>
     /// Standard types of images.

--- a/src/Snowflake.Framework.Tests.Input.Windows/Snowflake.Framework.Tests.Input.Windows.csproj
+++ b/src/Snowflake.Framework.Tests.Input.Windows/Snowflake.Framework.Tests.Input.Windows.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Snowflake.Framework.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
-
+    <_SnowflakeUseDevelopmentSDK>true</_SnowflakeUseDevelopmentSDK>
     <RootNamespace>Snowflake.Tests.Input.Windows</RootNamespace>
   </PropertyGroup>
 
@@ -25,10 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Snowflake.Framework.Dependencies\Snowflake.Framework.Dependencies.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework.Library\Snowflake.Framework.Library.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework.Primitives\Snowflake.Framework.Primitives.csproj" />
-    <ProjectReference Include="..\Snowflake.Framework\Snowflake.Framework.csproj" />
     <ProjectReference Include="..\Snowflake.Support.InputEnumerators.Windows\Snowflake.Support.InputEnumerators.Windows.csproj" />
   </ItemGroup>
 

--- a/src/Snowflake.Framework.Tests/Configuration/ConfigurationCollectionTests.cs
+++ b/src/Snowflake.Framework.Tests/Configuration/ConfigurationCollectionTests.cs
@@ -25,11 +25,14 @@ namespace Snowflake.Configuration.Tests
         [Fact]
         public void StringInitialization_Tests()
         {
+            var isoPath = Guid.NewGuid();
+            var fsR = Guid.NewGuid();
+
             var values = new List<(string, string, (string, Guid))>()
             {
-                ("ExampleConfiguration", "ISOPath0", ("Test", Guid.Empty)),
+                ("ExampleConfiguration", "ISOPath0", ("Test", isoPath)),
                 ("ExampleConfiguration", "FullscreenResolution",
-                    (FullscreenResolution.Resolution1024X600.ToString(), Guid.Empty))
+                    (FullscreenResolution.Resolution1024X600.ToString(), fsR))
             };
 
             var collection =
@@ -39,8 +42,8 @@ namespace Snowflake.Configuration.Tests
             Assert.Equal("Test", configuration.Configuration.ExampleConfiguration.ISOPath0);
             Assert.Equal(FullscreenResolution.Resolution1024X600,
                 configuration.Configuration.ExampleConfiguration.FullscreenResolution);
-            Assert.Equal(Guid.Empty, configuration.Configuration.ExampleConfiguration.Values["ISOPath0"].Guid);
-            Assert.Equal(Guid.Empty,
+            Assert.Equal(isoPath, configuration.Configuration.ExampleConfiguration.Values["ISOPath0"].Guid);
+            Assert.Equal(fsR,
                 configuration.Configuration.ExampleConfiguration.Values["FullscreenResolution"].Guid);
         }
 

--- a/src/Snowflake.Framework/Model/Database/PluginConfigurationStore.Async.cs
+++ b/src/Snowflake.Framework/Model/Database/PluginConfigurationStore.Async.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Snowflake.Configuration;
 using Snowflake.Extensibility.Configuration;
-using Snowflake.Model.Database.Exceptions;
 using Snowflake.Model.Database.Extensions;
 using Snowflake.Model.Database.Models;
 

--- a/src/Snowflake.Support.InputEnumerators.Windows/Snowflake.Support.InputEnumerators.Windows.csproj
+++ b/src/Snowflake.Support.InputEnumerators.Windows/Snowflake.Support.InputEnumerators.Windows.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>Snowflake.Support.InputEnumerators.Windows</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <_SnowflakeUseDevelopmentSDK>true</_SnowflakeUseDevelopmentSDK>
-
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Adds a `this[Guid]` indexer for `IConfigurationValueCollection` to allow this.
* Works in O(1) by keeping parallel dictionaries, also has the effect of ensuring config values are unique.
* Moves `ImageMetadataKeys` to `Snowflake.Model.Records.File` namespace
* Some tests for config deletion.