### PR TITLE
Device: add API for capability labels

### DIFF
--- a/src/Snowflake.Framework.Primitives/Input/Device/IDeviceCapabilityLabels.cs
+++ b/src/Snowflake.Framework.Primitives/Input/Device/IDeviceCapabilityLabels.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Snowflake.Input.Device
+{
+    /// <summary>
+    /// Represents a mapping from <see cref="DeviceCapability"/> to a label on the real device.
+    /// When enumerated, 
+    /// </summary>
+    public interface IDeviceCapabilityLabels : IEnumerable<KeyValuePair<DeviceCapability, string>>
+    {
+        /// <summary>
+        /// Gets a friendly string representation of the provided device capability.
+        /// </summary>
+        /// <param name="capability">The <see cref="DeviceCapability"/> to get a name for.</param>
+        /// <returns>A string representation of the device capbility</returns>
+        string this[DeviceCapability capability] { get; }
+    }
+}

--- a/src/Snowflake.Framework.Primitives/Input/Device/IInputDriverInstance.cs
+++ b/src/Snowflake.Framework.Primitives/Input/Device/IInputDriverInstance.cs
@@ -78,5 +78,11 @@ namespace Snowflake.Input.Device
         /// the natural mapping from controller element to a device capability.
         /// </summary>
         IDeviceLayoutMapping DefaultLayout { get; }
+
+        /// <summary>
+        /// Gets the friendly label names for capabilities this device instance supports.
+        /// This collection must at least have labels for all supported capabilities in <see cref="Capabilities"/>.
+        /// </summary>
+        IDeviceCapabilityLabels CapabilityLabels { get; }
     }
 }

--- a/src/Snowflake.Framework.Tests/Input/LabelsTests.cs
+++ b/src/Snowflake.Framework.Tests/Input/LabelsTests.cs
@@ -1,0 +1,35 @@
+﻿using Snowflake.Input.Device;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Snowflake.Input.Tests
+{
+    public class LabelsTests
+    {
+        [Fact]
+        public void DefaultLabels_Test()
+        {
+            Assert.Equal("Button0", DefaultDeviceCapabilityLabels.DefaultLabels[DeviceCapability.Button0]);
+            foreach(var (c, l) in DefaultDeviceCapabilityLabels.DefaultLabels)
+            {
+                Assert.Equal(l, c.ToString());
+            }
+        }
+
+        [Fact]
+        public void DictLabels_Test()
+        {
+            var dictLabels = new Dictionary<DeviceCapability, string>()
+            {
+                { DeviceCapability.Button0, "Button A" }
+            };
+
+            IDeviceCapabilityLabels labels = new DictionaryDeviceCapabilityLabels(dictLabels);
+            Assert.Equal("Button A", labels[DeviceCapability.Button0]);
+            Assert.Single(labels);
+            Assert.Equal(string.Empty, labels[DeviceCapability.Axis0Negative]);
+        }
+    }
+}

--- a/src/Snowflake.Framework/Input/Device/DefaultDeviceCapabilityLabels.cs
+++ b/src/Snowflake.Framework/Input/Device/DefaultDeviceCapabilityLabels.cs
@@ -1,0 +1,32 @@
+﻿using EnumsNET;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Snowflake.Input.Device
+{
+    /// <summary>
+    /// Implements a default label mapping using the name of the capability enum element.
+    /// </summary>
+    public sealed class DefaultDeviceCapabilityLabels : IDeviceCapabilityLabels
+    {
+        /// <summary>
+        /// Default labels using the name of the capability enum element.
+        /// </summary>
+        public static IDeviceCapabilityLabels DefaultLabels => _DefaultLabels;
+
+        private static readonly DefaultDeviceCapabilityLabels _DefaultLabels = new DefaultDeviceCapabilityLabels();
+
+        public string this[DeviceCapability capability] => Enums.AsString(capability);
+
+        public IEnumerator<KeyValuePair<DeviceCapability, string>> GetEnumerator()
+        {
+            return Enums.GetMembers<DeviceCapability>()
+                .Select(e => KeyValuePair.Create(e.Value, e.AsString())).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    }
+}

--- a/src/Snowflake.Framework/Input/Device/DictionaryDeviceCapabilityLabels.cs
+++ b/src/Snowflake.Framework/Input/Device/DictionaryDeviceCapabilityLabels.cs
@@ -1,0 +1,37 @@
+﻿using EnumsNET;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Snowflake.Input.Device
+{
+    /// <summary>
+    /// Implements a label mapping using a backing dictionary. Missing labels are replaced with
+    /// the empty string.
+    /// </summary>
+    public sealed class DictionaryDeviceCapabilityLabels : IDeviceCapabilityLabels
+    {
+        /// <summary>
+        /// Create a new <see cref="IDeviceCapabilityLabels"/> using a backing dictionary.
+        /// </summary>
+        /// <param name="labels">The backing dictionary to use.</param>
+        public DictionaryDeviceCapabilityLabels(IDictionary<DeviceCapability, string> labels)
+        {
+            this.Labels = labels;
+        }
+
+        private IDictionary<DeviceCapability, string> Labels { get; }
+       
+        public string this[DeviceCapability capability] => 
+            this.Labels.TryGetValue(capability, out string? value) ? value : string.Empty;
+
+        public IEnumerator<KeyValuePair<DeviceCapability, string>> GetEnumerator()
+        {
+            return this.Labels.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    }
+}

--- a/src/Snowflake.Framework/Input/Device/DirectInputDeviceInstance.cs
+++ b/src/Snowflake.Framework/Input/Device/DirectInputDeviceInstance.cs
@@ -9,8 +9,9 @@ namespace Snowflake.Input.Device
         internal DirectInputDeviceInstance(int enumerationIndex, 
             int classEnumerationIndex, int uniqueNameEnumerationIndex, 
             int productEnumerationIndex,
-            IReadOnlyDictionary<DeviceCapability, (int offset, int rawId)> capabilities, 
-            IDeviceLayoutMapping defaultLayout)
+            IReadOnlyDictionary<DeviceCapability, (int offset, int rawId)> capabilities,
+            IDeviceLayoutMapping defaultLayout,
+            IDeviceCapabilityLabels labels)
         {
             this.EnumerationIndex = enumerationIndex;
             this.ClassEnumerationIndex = classEnumerationIndex;
@@ -18,6 +19,7 @@ namespace Snowflake.Input.Device
             this.ProductEnumerationIndex = productEnumerationIndex;
             this.DefaultLayout = defaultLayout;
             this.CapabilityMap = capabilities;
+            this.CapabilityLabels = labels;
         }
 
         private IReadOnlyDictionary<DeviceCapability, (int offset, int rawId)> CapabilityMap { get; }
@@ -34,6 +36,8 @@ namespace Snowflake.Input.Device
         public IDeviceLayoutMapping DefaultLayout { get; }
 
         public int ProductEnumerationIndex { get; }
+
+        public IDeviceCapabilityLabels CapabilityLabels { get; }
 
         public int GetObjectOffset(DeviceCapability capability) => 
             this.CapabilityMap.TryGetValue(capability, out (int offset, int _) val) ? val.offset : -1;

--- a/src/Snowflake.Framework/Input/Device/KeyboardDeviceInstance.cs
+++ b/src/Snowflake.Framework/Input/Device/KeyboardDeviceInstance.cs
@@ -49,8 +49,8 @@ namespace Snowflake.Input.Device
             this.Capabilities = DeviceCapabilityClasses.Keyboard
                 .Concat(DeviceCapabilityClasses.MouseButtons)
                 .Concat(DeviceCapabilityClasses.MouseCursor)
-                .Concat(new[] { DeviceCapability.Axis0, 
-                    DeviceCapability.Axis0Negative, 
+                .Concat(new[] { DeviceCapability.Axis0,
+                    DeviceCapability.Axis0Negative,
                     DeviceCapability.Axis0Positive })
                 .ToList();
 
@@ -69,5 +69,7 @@ namespace Snowflake.Input.Device
         public int NameEnumerationIndex => 0;
 
         public int ProductEnumerationIndex => 0;
+
+        public IDeviceCapabilityLabels CapabilityLabels => DefaultDeviceCapabilityLabels.DefaultLabels;
     }
 }

--- a/src/Snowflake.Framework/Input/Device/PassthroughDeviceInstance.cs
+++ b/src/Snowflake.Framework/Input/Device/PassthroughDeviceInstance.cs
@@ -20,5 +20,7 @@ namespace Snowflake.Input.Device
         public int NameEnumerationIndex => 0;
 
         public int ProductEnumerationIndex => 0;
+
+        public IDeviceCapabilityLabels CapabilityLabels => DefaultDeviceCapabilityLabels.DefaultLabels;
     }
 }

--- a/src/Snowflake.Framework/Input/Device/XInputDeviceInstance.cs
+++ b/src/Snowflake.Framework/Input/Device/XInputDeviceInstance.cs
@@ -106,5 +106,8 @@ namespace Snowflake.Input.Device
         public IDeviceLayoutMapping DefaultLayout { get; }
 
         public int ProductEnumerationIndex => this.EnumerationIndex;
+
+        // todo: make XInput specific labels!
+        public IDeviceCapabilityLabels CapabilityLabels => DefaultDeviceCapabilityLabels.DefaultLabels;
     }
 }

--- a/src/Snowflake.Framework/Snowflake.Framework.xml
+++ b/src/Snowflake.Framework/Snowflake.Framework.xml
@@ -932,12 +932,34 @@
             <param name="vendor">The vendor ID of the physical device for this set of mappings.</param>
             <param name="mapping">The device layout mapping provided by the device enumerator.</param>
         </member>
+        <member name="T:Snowflake.Input.Device.DefaultDeviceCapabilityLabels">
+            <summary>
+            Implements a default label mapping using the name of the capability enum element.
+            </summary>
+        </member>
+        <member name="P:Snowflake.Input.Device.DefaultDeviceCapabilityLabels.DefaultLabels">
+            <summary>
+            Default labels using the name of the capability enum element.
+            </summary>
+        </member>
         <member name="M:Snowflake.Input.Device.DeviceCapabilityExtensions.GetClass(Snowflake.Input.Device.DeviceCapability)">
             <summary>
             Gets the capability class of this <see cref="T:Snowflake.Input.Device.DeviceCapability"/>
             </summary>
             <param name="this">The <see cref="T:Snowflake.Input.Device.DeviceCapability"/></param>
             <returns>The capability class of the capability.</returns>
+        </member>
+        <member name="T:Snowflake.Input.Device.DictionaryDeviceCapabilityLabels">
+            <summary>
+            Implements a label mapping using a backing dictionary. Missing labels are replaced with
+            the empty string.
+            </summary>
+        </member>
+        <member name="M:Snowflake.Input.Device.DictionaryDeviceCapabilityLabels.#ctor(System.Collections.Generic.IDictionary{Snowflake.Input.Device.DeviceCapability,System.String})">
+            <summary>
+            Create a new <see cref="T:Snowflake.Input.Device.IDeviceCapabilityLabels"/> using a backing dictionary.
+            </summary>
+            <param name="labels">The backing dictionary to use.</param>
         </member>
         <member name="T:Snowflake.Installation.Extensibility.GameInstaller">
             <inheritdoc cref="T:Snowflake.Installation.Extensibility.IGameInstaller" />

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Types/InputDevice/DeviceCapabilityLabelKeyValuePairGraphType.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Types/InputDevice/DeviceCapabilityLabelKeyValuePairGraphType.cs
@@ -1,0 +1,19 @@
+﻿using GraphQL.Types;
+using Snowflake.Input.Device;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Snowflake.Support.GraphQLFrameworkQueries.Types.InputDevice
+{
+    public class DeviceCapabilityLabelKeyValuePairGraphType : ObjectGraphType<KeyValuePair<DeviceCapability, string>>
+    {
+        public DeviceCapabilityLabelKeyValuePairGraphType()
+        {
+            Name = "DeviceCapabilityLabelKeyValuePair";
+            Description = "A label of a device capability";
+            Field<DeviceCapabilityEnum>("capability", description: "The capability this label describes.", resolve: c => c.Source.Key);
+            Field<StringGraphType>("label", description: "The label of the capability.", resolve: c => c.Source.Value);
+        }
+    }
+}

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Types/InputDevice/DeviceCapabilityLabelsGraphType.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Types/InputDevice/DeviceCapabilityLabelsGraphType.cs
@@ -1,0 +1,23 @@
+﻿using GraphQL.Types;
+using Snowflake.Input.Device;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Snowflake.Support.GraphQLFrameworkQueries.Types.InputDevice
+{
+    public class DeviceCapabilityLabelsGraphType : ObjectGraphType<IDeviceCapabilityLabels>
+    {
+        public DeviceCapabilityLabelsGraphType()
+        {
+            Name = "DeviceCapabilityLabels";
+            Description = "A mapping of device capabilities to friendly string labels.";
+            Field<ListGraphType<DeviceCapabilityLabelKeyValuePairGraphType>>("labels", description: "A list of labels in this device instance",
+                resolve: c => c.Source);
+            foreach (var (key, _) in DefaultDeviceCapabilityLabels.DefaultLabels)
+            {
+                Field<StringGraphType>(key.ToString(), resolve: c => c.Source[key] ?? key.ToString());
+            }
+        }
+    }
+}

--- a/src/Snowflake.Support.GraphQLFrameworkQueries/Types/InputDevice/InputDeviceInstanceGraphType.cs
+++ b/src/Snowflake.Support.GraphQLFrameworkQueries/Types/InputDevice/InputDeviceInstanceGraphType.cs
@@ -22,7 +22,7 @@ namespace Snowflake.Support.GraphQLFrameworkQueries.Types.InputDevice
                 resolve: context => context.Source.Capabilities);
             Field<ListGraphType<MappedControllerElementGraphType>>("defaultLayout",
                 description: "The default, assumed natural mapping from capability to virtual element without regard for any specific layout.",
-                resolve: context => (IEnumerable<MappedControllerElement>)context.Source.DefaultLayout);
+                resolve: context => context.Source.DefaultLayout);
             Field<IntGraphType>("enumerationIndex",
                 description: "When enumerating devices with a given driver, the index of enumeration for this driver.",
                 resolve: context => context.Source.EnumerationIndex);
@@ -41,6 +41,9 @@ namespace Snowflake.Support.GraphQLFrameworkQueries.Types.InputDevice
                             "with regards to the specific type of device, as determined by unique VID/product name," +
                             "if and only if the driver disambiguates between different devices.",
                 resolve: context => context.Source.ProductEnumerationIndex);
+            Field<DeviceCapabilityLabelsGraphType>("capabilityLabels",
+                description: "Friendly labels for the device capabilities of this instance",
+                resolve: context => context.Source.CapabilityLabels);
         }
     }
 }

--- a/src/Snowflake.Support.InputEnumerators.Windows/WindowsDeviceEnumerator.cs
+++ b/src/Snowflake.Support.InputEnumerators.Windows/WindowsDeviceEnumerator.cs
@@ -70,18 +70,16 @@ namespace Snowflake.Support.InputEnumerators.Windows
 
                 // todo add support for mapping overrides
                 instances.Add(new DirectInputDeviceInstance(allOrder, classOrder, nameOrder, prodOrder, capabilities, 
-                    GenerateDefaultMapping(capabilities.Keys)));
+                    GenerateDefaultMapping(capabilities.Keys), DefaultDeviceCapabilityLabels.DefaultLabels));
 
                 yield return new InputDevice(vid, pid,
                     name, name, path, device.Information.InstanceGuid, instances.AsReadOnly());
             }
-            
         }
 
         private static readonly IDictionary<DeviceCapability, ControllerElement> _hidMappings =
            new Dictionary<DeviceCapability, ControllerElement>()
            {
-
                 {DeviceCapability.Button0, ControllerElement.ButtonA},
                 {DeviceCapability.Button1, ControllerElement.ButtonB},
                 {DeviceCapability.Button2, ControllerElement.ButtonX},


### PR DESCRIPTION
Addresses #593 partially by providing a markup agnostic API for capability labels